### PR TITLE
Fix build pipeline broken by test suite

### DIFF
--- a/src/api/tsconfig.json
+++ b/src/api/tsconfig.json
@@ -19,5 +19,7 @@
     "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-  }
+  },
+  "include": ["./**/*.ts", "./**/*.tsx", "./**/*.d.ts"],
+  "exclude": ["./node_modules", "./tests"]
 }


### PR DESCRIPTION
I broke the build pipeline when I added a test suite for the `src/api/` setup.
This should fix it.

# Testing
At the top level of the repo, run `docker-compose -f docker-compose.production.yml build`