### PR TITLE
Downgrade date-fns from v4 to v3 for TypeScript 4.x compatibility

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,7 @@
 				"@sentry/node": "^7.53.1",
 				"@types/axios": "^0.14.0",
 				"cors": "^2.8.5",
-				"date-fns": "^4.1.0",
+				"date-fns": "^3.6.0",
 				"dotenv": "^8.6.0",
 				"express": "^4.17.1",
 				"express-handlebars": "^7.1.2",
@@ -2499,9 +2499,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -27790,9 +27790,9 @@
 			"dev": true
 		},
 		"date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+			"integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="
 		},
 		"debug": {
 			"version": "2.6.9",

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
 		"@sentry/node": "^7.53.1",
 		"@types/axios": "^0.14.0",
 		"cors": "^2.8.5",
-		"date-fns": "^4.1.0",
+		"date-fns": "^3.6.0",
 		"dotenv": "^8.6.0",
 		"express": "^4.17.1",
 		"express-handlebars": "^7.1.2",


### PR DESCRIPTION
This pull request downgrades the `date-fns` dependency from version 4.1.0 to 3.6.0 in the API service. The change is reflected in both `package.json` and `package-lock.json` to ensure consistency across environments.

Dependency management:

* Downgraded the `date-fns` package from version 4.1.0 to 3.6.0 in both `package.json` and `package-lock.json` to align with compatibility or stability requirements. [[1]](diffhunk://#diff-d0ab9c1cc78fba971b5270314ad877706d340d099b42f46a406fc5de6a32fdf0L20-R20) [[2]](diffhunk://#diff-5ceabdff55ebcf9aa8551146715d518c3d1454c7df52593dc510fedad73aca91L15-R15) [[3]](diffhunk://#diff-5ceabdff55ebcf9aa8551146715d518c3d1454c7df52593dc510fedad73aca91L2502-R2504) [[4]](diffhunk://#diff-5ceabdff55ebcf9aa8551146715d518c3d1454c7df52593dc510fedad73aca91L27793-R27795)