### PR TITLE
Use FOR XML PATH aggregation for secondaryNames

### DIFF
--- a/api/services/place-service.ts
+++ b/api/services/place-service.ts
@@ -345,7 +345,7 @@ export class PlaceService {
 					{ status: 'StatusTable.Status' },
 					{
 						secondaryNames: db.raw(
-							`(SELECT STRING_AGG(Description, ', ') FROM dbo.Name WHERE PlaceId = Place.Id)`
+							`STUFF((SELECT ', ' + Description FROM dbo.Name WHERE PlaceId = Place.Id FOR XML PATH('')), 1, 2, '')`
 						),
 					}
 				)


### PR DESCRIPTION
Replace STRING_AGG with STUFF(...) + FOR XML PATH('') to concatenate Name.Description values into a comma-separated secondaryNames field. This change avoids using STRING_AGG and improves compatibility with SQL Server versions that don't support that function.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
