### PR TITLE
Adding M2M service account authentication via API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Writing code and developing in this application requires running three services:
    docker compose -f docker-compose.development.yml up
    ```
 
-3. Run the database migrations by going to http://localhost:3000/migrate/latest
+3. Run the database migrations by going to <http://localhost:3000/migrate/latest>
 
-4. Create a new user account and log in to http://localhost:8080.
+4. Create a new user account and log in to <http://localhost:8080>.
 
 5. Once you are logged in, open a database console with `dev sqlcmd` and run the following command to give your user admin permissions:
 
@@ -42,13 +42,13 @@ Writing code and developing in this application requires running three services:
 
 To run the database locally, you must have Docker installed as well as Docker Compose, then run the following command from the root directory:
 
-```
+```sh
 docker-compose -f docker-compose.dev.yml up -d
 ```
 
 This command will start SQL Server and bind it to your local machine's port 1433. When it starts the first time, the database will be empty. To load it with data, you must obtain a database backup and put it into `/db/backups/yhsi.bak` then run the follow commands:
 
-```
+```sh
 dev exec db bash
 
 # or
@@ -57,14 +57,14 @@ docker compose -f docker-compose.development.yml exec db bash
 
 This connects you to the running SQL Server container. Once in, run the following commands to create and restore the database from the backup:
 
-```
+```sh
 cd /opt/mssql-tools/bin
 ./sqlcmd -U sa -s localhost -P 1m5ecure! -Q "RESTORE DATABASE YHSI FROM DISK = N'/backups/yhsi.bak' WITH FILE = 1"
 ```
 
 You will now have a local database with data ready for the API. To run the API, run the following commands:
 
-```
+```sh
 cd api
 npm install
 cp .env .env.development
@@ -72,21 +72,21 @@ cp .env .env.development
 
 You must then edit the `.env.development` file with the appropriate values for the local database and authentication before starting the Node.js API with:
 
-```
+```sh
 npm run start
 ```
 
-The API will bind to your local machines port 3000 and be available at http://localhost:3000
+The API will bind to your local machines port 3000 and be available at <http://localhost:3000>
 
 Last to start is the the Vue.js web front-end. To run this, open a second terminal window at this directory and run the following commands:
 
-```
+```sh
 cd web
 npm install
 npm run start
 ```
 
-You will now have the Vue CLI server hosting the application at http://localhost:8080 and you can begin editing the API or front-end code. **All changes to the files in the `api` and `web` will automatically reload theie respective applications.**
+You will now have the Vue CLI server hosting the application at <http://localhost:8080> and you can begin editing the API or front-end code. **All changes to the files in the `api` and `web` will automatically reload theie respective applications.**
 
 ## Local Testing
 
@@ -96,7 +96,7 @@ Only `api` has a test suite.
 
 To boot the test suite go to the top level of the app and run:
 
-```
+```sh
 bin/dev test up
 
 # or if you don't have ruby
@@ -143,7 +143,7 @@ fi
 exit 0
 ```
 
-2. Make the file executable vai `chmod +x .git/hooks/pre-commit`
+1. Make the file executable vai `chmod +x .git/hooks/pre-commit`
 
 ## Running the application production
 
@@ -156,30 +156,30 @@ the appropriate environment variables set using the following commands:
 
 1. Set the environment variables for the back-end.
 
-```
-cp /api/.env /api/.env.production
-vi /api/.env.production
-```
+    ```sh
+    cp /api/.env /api/.env.production
+    vi /api/.env.production
+    ```
 
 2. Set the global host port.
 
-```bash
-cp .env.sample .env
-vi .env
-```
+    ```bash
+    cp .env.sample .env
+    vi .env
+    ```
 
-> Note that the file needs to be named `.env` and it needs to be at the same level as
-> the `docker-compose.production.yml` file.
+    > Note that the file needs to be named `.env` and it needs to be at the same level as
+    > the `docker-compose.production.yml` file.
 
 3. Start the application with:
 
-```
-docker-compose -f docker-compose.production.yml up --build -d
-```
+    ```sh
+    docker-compose -f docker-compose.production.yml up --build -d
+    ```
 
-> To override an `.env` variable you can do `SOME_VAR=12345 docker-compose -f docker-compose.production.yml up --build -d`
+    > To override an `.env` variable you can do `SOME_VAR=12345 docker-compose -f docker-compose.production.yml up --build -d`
 
-When you look at the running Docker containers using `docker ps`, you should see a container named `yhsi_web_1`.
+    When you look at the running Docker containers using `docker ps`, you should see a container named `yhsi_web_1`.
 
-**One thing to keep in mind is that the port in the `docker-compose.prodution.yml` may need to be changed
-depending the the reverse proxy setups.**
+    **One thing to keep in mind is that the port in the `docker-compose.prodution.yml` may need to be changed
+    depending the the reverse proxy setups.**

--- a/api/@types/express/index.d.ts
+++ b/api/@types/express/index.d.ts
@@ -7,8 +7,8 @@ namespace Express {
 		session: any;
 		oidc: any;
 		textToMatch: string;
+		isServiceAccount?: boolean;
 
 		isAuthenticated(): boolean;
 	}
 }
-;

--- a/api/config.ts
+++ b/api/config.ts
@@ -58,3 +58,5 @@ export const GIS_FEATURE_PASSWORD = process.env.GIS_FEATURE_PASSWORD || '';
 
 // Configure Sentry (GlitchTip) for Monitorings)
 export const SENTRY_DSN = process.env.SENTRY_DSN || '';
+
+export const SERVICE_ACCOUNT_API_KEY = process.env.SERVICE_ACCOUNT_API_KEY || '';

--- a/api/index.ts
+++ b/api/index.ts
@@ -61,7 +61,7 @@ import {
 import * as config from './config';
 import { doHealthCheck } from './utils/healthCheck';
 import { configureAuthentication } from './routes/auth';
-import { RequiresAuthentication } from './middleware';
+import { RequiresAuthentication, injectServiceAccountMiddleware } from '@/middleware';
 import { CreateMigrationRoutes } from './data/migrator';
 
 import * as Sentry from '@sentry/node';
@@ -118,6 +118,7 @@ app.use(
 
 CreateMigrationRoutes(app);
 
+app.use('/api', injectServiceAccountMiddleware);
 configureAuthentication(app);
 
 app.get('/api/healthCheck', (_req: Request, res: Response) => {

--- a/api/middleware/authorization.ts
+++ b/api/middleware/authorization.ts
@@ -40,14 +40,11 @@ export function authorize(roles: string[] = [], allowPending = false) {
 		if (roles.length == 0) return next();
 
 		for (const role of roles) {
-			if (currentUser.roles && currentUser.roles.indexOf(role) >= 0)
-				return next();
+			if (currentUser.roles && currentUser.roles.indexOf(role) >= 0) return next();
 		}
 
 		//TODO for RYAN add an override for ADMINISTRATOR role, maybe? If it doesn't break anything?
 
-		return res
-			.status(403)
-			.json({ message: 'Unauthorized - Missing role(s): ' + roles });
+		return res.status(403).json({ message: 'Unauthorized - Missing role(s): ' + roles });
 	};
 }

--- a/api/middleware/authorization.ts
+++ b/api/middleware/authorization.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
-import { User, UserRoles } from '../models';
+import { isNil } from 'lodash';
+
+import { User, UserRoles } from '@/models';
 
 const USER_ACTIVE_STATUS = 'Active';
 
@@ -26,21 +28,33 @@ export const UserRoleOptions = [
 	UserRoles.INTERPRETIVE_SITES_VIEWER,
 ];
 
+/**
+ * REQUIRES injectServiceAccountMiddleware to run first
+ */
 export function authorize(roles: string[] = [], allowPending = false) {
 	return (req: Request, res: Response, next: NextFunction) => {
-		const currentUser = req.user as User;
+		const currentUser = req.user as User | undefined | null;
+		if (isNil(currentUser)) {
+			return res.status(403).json({ message: 'Unauthorized - User is nil' });
+		}
 
-		if (!req.oidc.isAuthenticated() || !currentUser)
+		if (!req.oidc.isAuthenticated() && !req.isServiceAccount) {
 			return res.status(401).send('Not authenticated');
+		}
 
-		if (currentUser.status != USER_ACTIVE_STATUS && !allowPending)
+		if (currentUser.status != USER_ACTIVE_STATUS && !allowPending) {
 			return res.status(403).json({ message: 'Unauthorized - User inactive' });
+		}
 
 		// if route only requires an active user
-		if (roles.length == 0) return next();
+		if (roles.length == 0) {
+			return next();
+		}
 
 		for (const role of roles) {
-			if (currentUser.roles && currentUser.roles.indexOf(role) >= 0) return next();
+			if (currentUser.roles && currentUser.roles.indexOf(role) >= 0) {
+				return next();
+			}
 		}
 
 		//TODO for RYAN add an override for ADMINISTRATOR role, maybe? If it doesn't break anything?

--- a/api/middleware/index.ts
+++ b/api/middleware/index.ts
@@ -1,8 +1,13 @@
 import { NextFunction, Request, Response } from 'express';
 import { validationResult } from 'express-validator';
+
 import { DB_HOST } from '../config';
 
 export function RequiresAuthentication(req: Request, res: Response, next: NextFunction) {
+	if (req.isServiceAccount) {
+		return next();
+	}
+
 	if (req.oidc.isAuthenticated()) {
 		return next();
 	}
@@ -28,3 +33,5 @@ export async function doHealthCheck(_req: Request, res: Response) {
 
 	res.send(`Connection to database on '<strong>${DB_HOST}</strong>' is connected and functioning.`);
 }
+
+export { injectServiceAccountMiddleware } from './inject-service-account-middleware';

--- a/api/middleware/inject-service-account-middleware.ts
+++ b/api/middleware/inject-service-account-middleware.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from 'express';
+import { isEmpty, isString, isUndefined } from 'lodash';
+import { timingSafeEqual } from 'crypto';
+
+import { SERVICE_ACCOUNT_API_KEY, DB_CONFIG } from '@/config';
+import { UserService } from '@/services';
+
+const SERVICE_ACCOUNT_EMAIL = 'service@yhsi.internal';
+const userService = new UserService(DB_CONFIG);
+
+export async function injectServiceAccountMiddleware(
+	req: Request,
+	res: Response,
+	next: NextFunction
+) {
+	if (isEmpty(SERVICE_ACCOUNT_API_KEY)) {
+		return next();
+	}
+
+	const token = req.headers['x-api-key'];
+	if (!isString(token)) {
+		return next();
+	}
+
+	if (token.length !== SERVICE_ACCOUNT_API_KEY.length) {
+		return next();
+	}
+
+	if (!timingSafeEqual(Buffer.from(token), Buffer.from(SERVICE_ACCOUNT_API_KEY))) {
+		return next();
+	}
+
+	try {
+		const serviceUser = await userService.getByEmail(SERVICE_ACCOUNT_EMAIL);
+		if (isUndefined(serviceUser)) {
+			throw new Error('Unable to find service account');
+		}
+
+		req.user = serviceUser;
+		req.isServiceAccount = true;
+	} catch (error) {
+		console.error(error);
+		return res.status(500).json({ message: 'Internal server error' });
+	}
+
+	return next();
+}
+
+export default injectServiceAccountMiddleware;

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -39,13 +39,13 @@ export function configureAuthentication(app: Express) {
 		})
 	);
 
-	app.use('/', async (req: Request, res: Response, next: NextFunction) => {
+	app.use('/', async (req: Request, _res: Response, next: NextFunction) => {
 		if (req.oidc.isAuthenticated()) {
-			let user = AuthUser.fromOpenId(req.oidc.user);
-			(req.session as any).user = user;
+			const user = AuthUser.fromOpenId(req.oidc.user);
+			req.session.user = user;
 			req.user = user;
 
-			let dbUser = await db.getByEmail(user.email);
+			const dbUser = await db.getByEmail(user.email);
 			req.user = dbUser; // Object.assign(user, dbUser);
 		}
 
@@ -54,10 +54,10 @@ export function configureAuthentication(app: Express) {
 
 	app.get('/', async (req: Request, res: Response) => {
 		if (req.oidc.isAuthenticated()) {
-			let user = AuthUser.fromOpenId(req.oidc.user);
+			const user = AuthUser.fromOpenId(req.oidc.user);
 			req.user = user;
 
-			let dbUser = await db.getByEmail(user.email);
+			const dbUser = await db.getByEmail(user.email);
 
 			if (!dbUser) {
 				if (user.first_name == null || user.last_name == null) {
@@ -79,7 +79,7 @@ export function configureAuthentication(app: Express) {
 
 	app.get('/api/auth/isAuthenticated', async (req: Request, res: Response) => {
 		if (req.oidc.isAuthenticated()) {
-			let person = req.user;
+			const person = req.user;
 			//let me = await db.getByEmail(person.email);
 			return res.json({ data: person });
 		}
@@ -87,21 +87,9 @@ export function configureAuthentication(app: Express) {
 		return res.status(401).send();
 	});
 
-	app.get('/api/auth/logout', async (req: any, res) => {
+	app.get('/api/auth/logout', async (req: Request, res: Response) => {
 		req.session.destroy();
 		res.status(401);
-		await (res as any).oidc.logout();
+		await res.oidc.logout();
 	});
-}
-
-export function EnsureAuthenticated(
-	req: Request,
-	res: Response,
-	next: NextFunction
-) {
-	if (req.oidc.isAuthenticated()) {
-		return next();
-	}
-
-	res.status(401).send('Not authenticated'); //;.redirect('/api/auth/login');
 }


### PR DESCRIPTION
# Context

YRHP requires read access to YHSI data without a user login session.

# Implementation

- Added `SERVICE_ACCOUNT_KEY` env var — when set, enables M2M authentication
- `SERVICE_ACCOUNT_KEY` unset (or empty) disables M2M entirely



# Usage

1. Generate a key and set it in the environment:
    ```sh
    openssl rand -hex 32
    ```
    In `.env`:
    ```sh
    SERVICE_ACCOUNT_KEY=<generated key>
    ```
2. On each request add key to `x-api-key` header. Example usage:
  ```sh
  curl https://your-api/api/place -H "x-api-key: <key>"
  ```
  
# Change Request: Seed Service Account

A user with email `service@yhsi.internal` and status `Active` must exist in the database before M2M requests will work. Assign it the roles appropriate for the consuming application.