### PR TITLE
Fix left-indent of standalone fields in Sites PDF sections

### DIFF
--- a/api/templates/places/placePrint.handlebars
+++ b/api/templates/places/placePrint.handlebars
@@ -95,6 +95,12 @@
 			.field {
 				margin: 0 0 10px;
 			}
+			.section > .field,
+			.section > .empty,
+			.section > .divider {
+				margin-left: 16px;
+				margin-right: 16px;
+			}
 			.field .label {
 				display: block;
 				font-weight: 600;
@@ -417,7 +423,7 @@
 							</tr>
 						{{else}}
 							<tr>
-								<td><div class='empty'>No photos</div></td>
+								<td><div class='subfield empty'>No photos</div></td>
 							</tr>
 						{{/each}}
 					</tbody>

--- a/api/templates/styles.css
+++ b/api/templates/styles.css
@@ -102,6 +102,14 @@ div.general {
 .field {
 	margin: 0 0 10px;
 }
+/* Standalone fields/empties placed directly in a section need the same
+   16px indent that .subhead, .subfield and .divided-row cells carry. */
+.section > .field,
+.section > .empty,
+.section > .divider {
+	margin-left: 16px;
+	margin-right: 16px;
+}
 .field .label {
 	display: block;
 	font-weight: 600;


### PR DESCRIPTION
Standalone .field elements (Statute, Description) and empty states sat flush at the edge while .subhead/.subfield/.divided-row content carried a 16px indent. Indent them consistently and align the photos empty state with the other 'None recorded' states.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
