### PR TITLE
Normalize single-item PDF view templates to shared Sites styling

### DIFF
--- a/api/routes/aircrash-router.ts
+++ b/api/routes/aircrash-router.ts
@@ -233,7 +233,7 @@ aircrashRouter.post(
 				data: aircrash,
 			});
 
-			const pdf = await generatePDF(data);
+			const pdf = await generatePDF(data, 'letter', false);
 			res.setHeader('Content-disposition', `attachment; filename="aircrash-${aircrashId}.pdf"`);
 			res.setHeader('Content-type', 'application/pdf');
 			res.send(pdf);

--- a/api/routes/boat-router.ts
+++ b/api/routes/boat-router.ts
@@ -236,7 +236,7 @@ boatsRouter.post(
 			data: boat,
 		});
 
-		let pdf = await generatePDF(data);
+		let pdf = await generatePDF(data, 'letter', false);
 		res.setHeader('Content-disposition', 'attachment; filename="burials.html"');
 		res.setHeader('Content-type', 'application/pdf');
 		res.send(pdf);

--- a/api/routes/burials-router.ts
+++ b/api/routes/burials-router.ts
@@ -452,7 +452,7 @@ burialsRouter.post(
 			data: burial,
 		});
 
-		const pdf = await generatePDF(data);
+		const pdf = await generatePDF(data, 'letter', false);
 		res.setHeader('Content-disposition', 'attachment; filename="burials.html"');
 		res.setHeader('Content-type', 'application/pdf');
 		res.send(pdf);

--- a/api/routes/interpretive-sites-router.ts
+++ b/api/routes/interpretive-sites-router.ts
@@ -146,7 +146,7 @@ intSitesRouter.post(
 				data: item,
 			});
 
-			const pdf = await generatePDF(data);
+			const pdf = await generatePDF(data, 'letter', false);
 			res.setHeader('Content-disposition', 'attachment; filename="interpretiveSite.html"');
 			res.setHeader('Content-type', 'application/pdf');
 			res.send(pdf);

--- a/api/routes/owner-router.ts
+++ b/api/routes/owner-router.ts
@@ -157,7 +157,7 @@ ownerRouter.post(
 			data: owner,
 		});
 
-		const pdf = await generatePDF(data);
+		const pdf = await generatePDF(data, 'letter', false);
 		res.setHeader('Content-disposition', 'attachment; filename="burials.html"');
 		res.setHeader('Content-type', 'application/pdf');
 		res.send(pdf);

--- a/api/routes/people-router.ts
+++ b/api/routes/people-router.ts
@@ -213,7 +213,7 @@ peopleRouter.post(
 			data: person,
 		});
 
-		const pdf = await generatePDF(data);
+		const pdf = await generatePDF(data, 'letter', false);
 		res.setHeader('Content-disposition', 'attachment; filename="burials.html"');
 		res.setHeader('Content-type', 'application/pdf');
 		res.send(pdf);

--- a/api/templates/aircrashes/aircrashView.pug
+++ b/api/templates/aircrashes/aircrashView.pug
@@ -1,76 +1,109 @@
 //- template.pug
 
 style
-     include ../styles.css
-    
+  include ../styles.css
+  | @page { margin: 24px; }
+
 table.title-row
-  tbody 
-    tr 
-      td
-        div Aircrash information
-        div.item-name #{data.yacsinumber} #{data.aircrafttype}  (#{data.aircraftregistration})
-      td
-        div(style='width:200px;')
-          include ../yukon.svg
-
-div.section-title General information
-
-table.divided-row
-  tbody 
-    tr 
-      td
-        div YACSI Number: #{data.yacsinumber}
-        div Aircraft Maker/Model: #{data.aircrafttype}
-        div Crash Date: #{data.crashdate}
-        div Pilot: #{data.pilotrank} #{data.pilotfirstname} #{data.pilotlastname}
-      td
-        div Aircraft Registration: #{data.aircraftregistration}
-        div Country of Registration: #{data.nation}
-        div Registration Type: #{data.militarycivilian}
-
-div.section-title Location Details
-table.divided-row
-  tbody 
-    tr 
-      td
-        div Latitude: #{data.lat}
-        div Longitude: #{data.long}
-        div Accuracy: #{data.accuracy}
-        div Crash site within Yukon?: #{data.inyukon}
-      td
-        div Location Description: #{data.crashlocation}
-
-div.section-title Crash Details
-table.divided-row
-  tbody 
-    tr 
-      td
-        div Remains on site: #{data.remainsonsite}
-        div Extent of remains on site: #{data.extentofremainsonsite}
-        div Other location of remains: #{data.otherlocationsofremains}
-        div Description of crash event: #{data.descriptionofcrashevent}
-      td
-        div Souls on board: #{data.soulsonboard}
-        div Injuries: #{data.injuries}
-        div Fatalities: #{data.fatalities}
-        div Additional Info: #{data.comments}
-        
-div.section-title Crash Sources
-table.divided-row
   tbody
     tr
       td
-        div Significance of aircraft: #{data.significanceofaircraft}
-      td
-        table.table-full-width
-          thead 
-            tr 
-              td Source
-          tbody
-            each val in data.infoSources
-              tr 
-                td #{val.Source}
+        div(style="margin-top: 15px") Yukon Heritage Information System
+        div.item-name #{data.yacsinumber} #{data.aircrafttype} (#{data.aircraftregistration})
+      td.brand-logo
+        include ../yukon.svg
 
-        
-        
-        
+div.section
+  div.section-title General information
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label YACSI Number
+            span.value #{data.yacsinumber}
+          div.field
+            span.label Aircraft Maker/Model
+            span.value #{data.aircrafttype}
+          div.field
+            span.label Crash Date
+            span.value #{data.crashdate}
+          div.field
+            span.label Pilot
+            span.value #{data.pilotrank} #{data.pilotfirstname} #{data.pilotlastname}
+        td
+          div.field
+            span.label Aircraft Registration
+            span.value #{data.aircraftregistration}
+          div.field
+            span.label Country of Registration
+            span.value #{data.nation}
+          div.field
+            span.label Registration Type
+            span.value #{data.militarycivilian}
+
+div.section
+  div.section-title Location Details
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Latitude
+            span.value #{data.lat}
+          div.field
+            span.label Longitude
+            span.value #{data.long}
+          div.field
+            span.label Accuracy
+            span.value #{data.accuracy}
+          div.field
+            span.label Crash site within Yukon?
+            span.value #{data.inyukon}
+        td
+          div.field
+            span.label Location Description
+            span.value #{data.crashlocation}
+
+div.section
+  div.section-title Crash Details
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Remains on site
+            span.value #{data.remainsonsite}
+          div.field
+            span.label Extent of remains on site
+            span.value #{data.extentofremainsonsite}
+          div.field
+            span.label Other location of remains
+            span.value #{data.otherlocationsofremains}
+          div.field
+            span.label Description of crash event
+            span.value #{data.descriptionofcrashevent}
+        td
+          div.field
+            span.label Souls on board
+            span.value #{data.soulsonboard}
+          div.field
+            span.label Injuries
+            span.value #{data.injuries}
+          div.field
+            span.label Fatalities
+            span.value #{data.fatalities}
+          div.field
+            span.label Additional Info
+            span.value #{data.comments}
+
+div.section
+  div.section-title Crash Sources
+  div.field
+    span.label Significance of aircraft
+    span.value #{data.significanceofaircraft}
+  div.subhead Sources
+  each val in data.infoSources
+    div.subfield #{val.Source}
+  else
+    div.subfield.empty None recorded

--- a/api/templates/boat-owners/boatOwnerView.pug
+++ b/api/templates/boat-owners/boatOwnerView.pug
@@ -1,51 +1,37 @@
 //- template.pug
 
 style
-     include ../styles.css
+  include ../styles.css
+  | @page { margin: 24px; }
 
 table.title-row
-  tbody 
-    tr 
-      td
-        div Owner information
-        div.item-name #{data.Name} 
-      td
-        div(style='width:200px;')
-          include ../yukon.svg
-
-div.section-title General information
-
-table.table-full-width.center
-  thead 
-    tr 
-      td 
-        strong.underline Alias 
-  tbody 
-    each val in data.alias
-      tr 
-        td #{val.Alias}
-
-table.table-full-width.center
-  thead 
-    tr 
-      td 
-        strong.underline Boats Owned 
-  tbody 
-    each val in data.boats
-      tr 
-        td #{val.Name}
-
-div.section-title History
-
-table.table-full-width.center
-  thead 
-    tr 
-      td
-        strong.underline Historic Record 
-      td
-        strong.underline Reference 
   tbody
-    each val in data.histories
-      tr 
-        td #{val.HistoryText}
-        td #{val.Reference}
+    tr
+      td
+        div(style="margin-top: 15px") Yukon Heritage Information System
+        div.item-name #{data.Name}
+      td.brand-logo
+        include ../yukon.svg
+
+div.section
+  div.section-title General information
+  div.subhead Alias
+  each val in data.alias
+    div.subfield #{val.Alias}
+  else
+    div.subfield.empty None recorded
+  div.subhead Boats Owned
+  each val in data.boats
+    div.subfield #{val.Name}
+  else
+    div.subfield.empty None recorded
+
+div.section
+  div.section-title History
+  each val in data.histories
+    div.subfield
+      | #{val.HistoryText}
+      br
+      em Reference: #{val.Reference}
+  else
+    div.subfield.empty None recorded

--- a/api/templates/boats/boatView.pug
+++ b/api/templates/boats/boatView.pug
@@ -1,70 +1,69 @@
 //- template.pug
 
 style
-     include ../styles.css
-    
+  include ../styles.css
+  | @page { margin: 24px; }
+
 table.title-row
-  tbody 
-    tr 
-      td
-        div Boats information
-        div.item-name #{data.Name}  
-      td
-        div(style='width:200px;')
-          include ../yukon.svg
-
-
-div.section-title General information
- 
-table.divided-row
-  tbody 
-    tr 
-      td
-        div Name: #{data.Name}
-        div Registration Number: #{data.RegistrationNumber}
-        div Vessel Type: #{data.VesselType}
-        div Current Location Description: #{data.CurrentLocation}
-      td
-        div Construction Date: #{data.ConstructionDate}
-        div Service Start Date: #{data.ServiceStart}
-        div Service End Date: #{data.ServiceEnd}
-        div Notes: #{data.Notes}
-
-
-div.section-title Owners/Names
-table.divided-row 
-  tbody 
-    tr 
-      td 
-        table.table-full-width 
-          thead 
-            tr 
-              td Owners 
-          tbody 
-            each val in data.owners
-              tr 
-                td #{val.OwnerName}
-      td 
-        table.table-full-width 
-          thead 
-            tr 
-              td Names 
-          tbody 
-            each val in data.pastNames
-              tr 
-                td #{val.BoatName}
-
-div.section-title History
-
-table.table-full-width.center
-  thead 
-    tr 
-      td
-        strong.underline Historic Record 
-      td
-        strong.underline Reference 
   tbody
-    each val in data.histories
-      tr 
-        td #{val.HistoryText}
-        td #{val.Reference}
+    tr
+      td
+        div(style="margin-top: 15px") Yukon Heritage Information System
+        div.item-name #{data.Name}
+      td.brand-logo
+        include ../yukon.svg
+
+div.section
+  div.section-title General information
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Name
+            span.value #{data.Name}
+          div.field
+            span.label Registration Number
+            span.value #{data.RegistrationNumber}
+          div.field
+            span.label Vessel Type
+            span.value #{data.VesselType}
+          div.field
+            span.label Current Location Description
+            span.value #{data.CurrentLocation}
+        td
+          div.field
+            span.label Construction Date
+            span.value #{data.ConstructionDate}
+          div.field
+            span.label Service Start Date
+            span.value #{data.ServiceStart}
+          div.field
+            span.label Service End Date
+            span.value #{data.ServiceEnd}
+          div.field
+            span.label Notes
+            span.value #{data.Notes}
+
+div.section
+  div.section-title Owners & Names
+  div.subhead Owners
+  each val in data.owners
+    div.subfield #{val.OwnerName}
+  else
+    div.subfield.empty None recorded
+  div.subhead Names
+  each val in data.pastNames
+    div.subfield #{val.BoatName}
+  else
+    div.subfield.empty None recorded
+
+div.section
+  div.section-title History
+  each val in data.histories
+    div.subfield
+      | #{val.HistoryText}
+      br
+      em Reference: #{val.Reference}
+  else
+    div.subfield.empty None recorded

--- a/api/templates/burials/burialView.pug
+++ b/api/templates/burials/burialView.pug
@@ -1,138 +1,116 @@
 //- template.pug
 
 style
-     include ../styles.css
-    
+  include ../styles.css
+  | @page { margin: 24px; }
+
 table.title-row
-  tbody 
-    tr 
-      td
-        div Burial information
-        div.item-name #{data.LastName}, #{data.FirstName} 
-      td
-        div(style='width:200px;')
-          include ../yukon.svg
-
-
-div.section-title Personal information
- 
-table.divided-row
-  tbody 
-    tr 
-      td
-        div First Name: #{data.FirstName}
-        div Last Name: #{data.LastName}
-        div Alternate Name/Spelling: #{data.Manner}
-        div Gender: #{data.Gender}
-      td
-        div Origin: #{data.OriginCity}, #{data.OriginCountry}
-        div Birth Date: #{data.BirthDay}/#{data.BirthMonth}/#{data.BirthYear}
-        div Death Date: #{data.DeathDay}/#{data.DeathMonth}/#{data.DeathYear}
-
-div.section-title History
-table.full-width.table-display.general
   tbody
-      tr 
-        td
-          table.religion-table.table-full-width 
-            thead 
-              tr 
-                td 
-                  strong.underline Religion
-            tbody 
-                tr 
-                  td #{data.Religion.Religion}
-        td
-          table.table-full-width
-            thead 
-              tr 
-                td 
-                  strong.underline Occupations
-            tbody 
-              each val in data.Occupations
-                tr 
-                  td #{val.Occupation}
-        td
-          table.membership-table.table-full-width
-            thead 
-              tr 
-                td
-                  strong.underline Memberships
-                td 
-            tbody 
-              each val in data.Memberships
-                tr
-                  td #{val.Membership}
-                  td  #{val.Chapter}
-      
-
-div.section-title Death 
-table.divided-row 
-  tbody
-      tr 
-        td
-          div Manner: #{data.Manner}
-        td
-          div Cause: #{data.Cause.Cause}
-
-div.section-title Funeral/Obituary
-div.row-container Funneral Paid By: #{data.FunneralPaidBy}
-table.divided-row 
-  tbody
-    tr 
-      td 
-        table.table-full-width
-          thead 
-            tr 
-              td
-                strong.underline Sources
-          tbody 
-            each val in data.Sources
-              tr
-                td #{val.Source}
-      td 
-        table.table-full-width
-          thead 
-            tr 
-              td
-                strong.underline Next of Kin
-          tbody 
-            each val in data.Kinships
-              tr
-                td #{val.Name} - #{val.Relationship} - #{val.Location}
-div.section-title Burial Location
-
-table.table-full-width.center
-  tbody 
-    tr 
-      td Burial Location: 
-      td #{data.OtherCemetaryDesc}  
-    tr 
-      td Plot Description:
-      td #{data.PlotDescription} 
-
-div.section-title Marker/Site Visit
-
-table.table-full-width.center
-  thead 
-    tr 
+    tr
       td
-        strong.underline Marker Description
-      td
-        strong.underline Inscription
-      td
-        strong.underline Condition
-      td
-        strong.underline Date Visited
-      td
-        strong.underline Visited By
-  tbody 
-    each val in data.SiteVisits
+        div(style="margin-top: 15px") Yukon Heritage Information System
+        div.item-name #{data.LastName}, #{data.FirstName}
+      td.brand-logo
+        include ../yukon.svg
+
+div.section
+  div.section-title Personal information
+  table.divided-row
+    tbody
       tr
-        td #{val.MarkerDescription} 
-        td #{val.Inscription} 
-        td #{val.Condition} 
-        td #{val.VisitYear} 
-        td #{val.RecordedBy} 
-        
+        td
+          div.field
+            span.label First Name
+            span.value #{data.FirstName}
+          div.field
+            span.label Last Name
+            span.value #{data.LastName}
+          div.field
+            span.label Alternate Name/Spelling
+            span.value #{data.Manner}
+          div.field
+            span.label Gender
+            span.value #{data.Gender}
+        td
+          div.field
+            span.label Origin
+            span.value #{data.OriginCity}, #{data.OriginCountry}
+          div.field
+            span.label Birth Date
+            span.value #{data.BirthDay}/#{data.BirthMonth}/#{data.BirthYear}
+          div.field
+            span.label Death Date
+            span.value #{data.DeathDay}/#{data.DeathMonth}/#{data.DeathYear}
 
+div.section
+  div.section-title History
+  div.subhead Religion
+  div.subfield #{data.Religion.Religion}
+  div.subhead Occupations
+  each val in data.Occupations
+    div.subfield #{val.Occupation}
+  else
+    div.subfield.empty None recorded
+  div.subhead Memberships
+  each val in data.Memberships
+    div.subfield #{val.Membership} - #{val.Chapter}
+  else
+    div.subfield.empty None recorded
+
+div.section
+  div.section-title Death
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Manner
+            span.value #{data.Manner}
+        td
+          div.field
+            span.label Cause
+            span.value #{data.Cause.Cause}
+
+div.section
+  div.section-title Funeral/Obituary
+  div.field
+    span.label Funeral Paid By
+    span.value #{data.FunneralPaidBy}
+  div.subhead Sources
+  each val in data.Sources
+    div.subfield #{val.Source}
+  else
+    div.subfield.empty None recorded
+  div.subhead Next of Kin
+  each val in data.Kinships
+    div.subfield #{val.Name} - #{val.Relationship} - #{val.Location}
+  else
+    div.subfield.empty None recorded
+
+div.section
+  div.section-title Burial Location
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Burial Location
+            span.value #{data.OtherCemetaryDesc}
+        td
+          div.field
+            span.label Plot Description
+            span.value #{data.PlotDescription}
+
+div.section
+  div.section-title Marker/Site Visit
+  each val in data.SiteVisits
+    div.subfield
+      strong Visited #{val.VisitYear} by #{val.RecordedBy}
+      br
+      | Marker: #{val.MarkerDescription}
+      br
+      | Inscription: #{val.Inscription}
+      br
+      | Condition: #{val.Condition}
+  else
+    div.subfield.empty None recorded

--- a/api/templates/interpretive-sites/interpretiveSitesView.pug
+++ b/api/templates/interpretive-sites/interpretiveSitesView.pug
@@ -1,121 +1,113 @@
 //- template.pug
 
 style
-     include ../styles.css
-    
+  include ../styles.css
+  | @page { margin: 24px; }
+
 table.title-row
-  tbody 
-    tr 
-      td
-        div Interpretive Site Information
-        div.item-name #{data.SiteName}
-      td
-        div(style='width:200px;')
-          include ../yukon.svg
-
-
-div.section-title Site information
- 
-table.divided-row
-  tbody 
-    tr 
-      td
-        div Site Name: #{data.FirstName}
-        div Established Year: #{data.EstablishedYear}
-        div Maintained By: #{data.MaintainedBy}
-      td
-        div Advanced Notification Signs: #{data.AdvancedNotification}
-        div Advanced Notification Description: #{data.NotificationDesc}
-
-div.section-title Location
-table.full-width.table-display.general
   tbody
-      tr 
-        td
-          div Location Description: #{data.LocationDesc}
-          div Route Name: #{data.RouteName}
-          div MapSheet: #{data.MapSheet}
-        td
-          div KMNumber: #{data.KMNumber}
-          div Latitude: #{data.Latitude}
-          div Longitude: #{data.Longitude}  
-
-div.section-title Assets
-
-table.table-full-width.center
-  thead 
-    tr 
-      td 
-        strong.underline Category 
-      td 
-        strong.underline Type
-      td 
-        strong.underline Size
-      td 
-        strong.underline Description
-      td 
-        strong.underline Sign Text
-      td 
-        strong.underline Install Date
-      td 
-        strong.underline Active
-  tbody 
-    each val in data.assets
-      tr 
-          td #{val.Category} 
-          td #{val.Type} 
-          td #{val.Size} 
-          td #{val.Description} 
-          td #{val.SignText} 
-          td #{val.InstallDate} 
-          td #{val.Status} 
-
-div.section-title Actions
-
-table.table-full-width.center
-  thead 
-    tr 
-      td 
-        strong.underline Action Description 
-      td 
-        strong.underline To Be Complete Date
-      td 
-        strong.underline Action Complete Date
-      td 
-        strong.underline Route
-      td 
-        strong.underline Completion Description
-      td 
-        strong.underline Priority
-  tbody 
-    each val in data.actions
-        tr 
-          td #{val.ActionDesc} 
-          td #{val.ToBeCompleteDate} 
-          td #{val.ActionCompleteDate} 
-          td #{val.Route} 
-          td #{val.CompletionDesc} 
-          td #{val.Priority} 
-
-div.section-title Inspections
-
-table.table-full-width.center
-  thead 
-    tr 
+    tr
       td
-        strong.underline Inspection Date
-      td
-        strong.underline Description
-      td
-        strong.underline Inspected By
-      td
-        strong.underline Actions
-  tbody 
-    each val in data.inspections
+        div(style="margin-top: 15px") Yukon Heritage Information System
+        div.item-name #{data.SiteName}
+      td.brand-logo
+        include ../yukon.svg
+
+div.section
+  div.section-title Site information
+  table.divided-row
+    tbody
       tr
-        td #{val.InspectionDate} 
-        td #{val.Description} 
-        td #{val.InspectedBy} 
-        td #{val.Actions} 
-        
+        td
+          div.field
+            span.label Site Name
+            span.value #{data.SiteName}
+          div.field
+            span.label Established Year
+            span.value #{data.EstablishedYear}
+          div.field
+            span.label Maintained By
+            span.value #{data.MaintainedBy}
+        td
+          div.field
+            span.label Advanced Notification Signs
+            span.value #{data.AdvancedNotification}
+          div.field
+            span.label Advanced Notification Description
+            span.value #{data.NotificationDesc}
 
+div.section
+  div.section-title Location
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Location Description
+            span.value #{data.LocationDesc}
+          div.field
+            span.label Route Name
+            span.value #{data.RouteName}
+          div.field
+            span.label Map Sheet
+            span.value #{data.MapSheet}
+        td
+          div.field
+            span.label KM Number
+            span.value #{data.KMNumber}
+          div.field
+            span.label Latitude
+            span.value #{data.Latitude}
+          div.field
+            span.label Longitude
+            span.value #{data.Longitude}
+
+div.section
+  div.section-title Assets
+  each val in data.assets
+    div.subfield
+      strong #{val.Category} - #{val.Type}
+      br
+      | Size: #{val.Size}
+      br
+      | Description: #{val.Description}
+      br
+      | Sign Text: #{val.SignText}
+      br
+      | Install Date: #{val.InstallDate}
+      br
+      | Active: #{val.Status}
+  else
+    div.subfield.empty None recorded
+
+div.section
+  div.section-title Actions
+  each val in data.actions
+    div.subfield
+      strong #{val.ActionDesc}
+      br
+      | To Be Complete: #{val.ToBeCompleteDate}
+      br
+      | Completed: #{val.ActionCompleteDate}
+      br
+      | Route: #{val.Route}
+      br
+      | Completion Description: #{val.CompletionDesc}
+      br
+      | Priority: #{val.Priority}
+  else
+    div.subfield.empty None recorded
+
+div.section
+  div.section-title Inspections
+  each val in data.inspections
+    div.subfield
+      strong #{val.InspectionDate}
+      br
+      | Description: #{val.Description}
+      br
+      | Inspected By: #{val.InspectedBy}
+      br
+      | Actions: #{val.Actions}
+  else
+    div.subfield.empty None recorded

--- a/api/templates/people/peopleView.pug
+++ b/api/templates/people/peopleView.pug
@@ -1,44 +1,47 @@
 //- template.pug
 
 style
-     include ../styles.css
+  include ../styles.css
+  | @page { margin: 24px; }
 
 table.title-row
-  tbody 
-    tr 
-      td
-        div Person information
-        div.item-name #{data.Surname}, #{data.GivenName}
-      td
-        div(style='width:200px;')
-          include ../yukon.svg
-
-div.section-title Personal information
- 
-table.divided-row
-  tbody 
-    tr 
-      td
-        div Sur Name: #{data.Surname}
-        div Given Name: #{data.GivenName}
-        div Notes: #{data.Notes}
-      td
-        div Birth Year: #{data.BirthYear}
-        div Death Year: #{data.DeathYear}
-
-div.section-title History
-
-table.table-full-width.center
-  thead 
-    tr 
-      td
-        strong.underline Historic Record 
-      td
-        strong.underline Reference 
   tbody
-    each val in data.histories
-      tr 
-        td #{val.HistoryText}
-        td #{val.Reference}
-        
+    tr
+      td
+        div(style="margin-top: 15px") Yukon Heritage Information System
+        div.item-name #{data.Surname}, #{data.GivenName}
+      td.brand-logo
+        include ../yukon.svg
 
+div.section
+  div.section-title Personal information
+  table.divided-row
+    tbody
+      tr
+        td
+          div.field
+            span.label Surname
+            span.value #{data.Surname}
+          div.field
+            span.label Given Name
+            span.value #{data.GivenName}
+          div.field
+            span.label Notes
+            span.value #{data.Notes}
+        td
+          div.field
+            span.label Birth Year
+            span.value #{data.BirthYear}
+          div.field
+            span.label Death Year
+            span.value #{data.DeathYear}
+
+div.section
+  div.section-title History
+  each val in data.histories
+    div.subfield
+      | #{val.HistoryText}
+      br
+      em Reference: #{val.Reference}
+  else
+    div.subfield.empty None recorded

--- a/api/templates/styles.css
+++ b/api/templates/styles.css
@@ -56,6 +56,10 @@ div.general {
 	font-weight: 700;
 	margin-top: 2px;
 }
+.brand-logo svg {
+	width: 180px;
+	height: auto;
+}
 
 /* ---- Section header bar ---- */
 .section-title {


### PR DESCRIPTION
Apply the Sites print's exact header (Yukon Heritage Information System + item name + right-aligned logo) and field/section styling to the six single-item view templates (boats, people, burials, boat owners, aircrashes, interpretive sites). Plain 'Label: value' rows become the .field label/value pattern, record lists render as .subhead/.subfield blocks, and the views now print portrait with 24px margins like Sites.

Grid/list templates are intentionally left unchanged.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
