### PR TITLE
Qualify showInRegister in place queries

### DIFF
--- a/api/services/place-service.ts
+++ b/api/services/place-service.ts
@@ -119,7 +119,7 @@ export class PlaceService {
 						db.raw('(select min(PH.DateCreated) from dbo.photo as PH where PH.PlaceId = Place.Id)')
 					);
 			})
-			.where({ showInRegister: true })
+			.where({ "place.showInRegister": true })
 			.whereNull('Place.deleted_at')
 			.orderBy('Place.Id')
 			.offset(skip)
@@ -132,7 +132,7 @@ export class PlaceService {
 				.count('*', {
 					as: 'count',
 				})
-				.where({ showInRegister: true })
+				.where({ "place.showInRegister": true })
 				.whereNull('deleted_at');
 
 			if (results) {


### PR DESCRIPTION
Updated `PlaceService` register list and count queries to use `place.showInRegister` instead of an unqualified `showInRegister` column. This prevents ambiguous column resolution and ensures filtering is applied to the `place` table when joins are present.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
