### PR TITLE
Refine register photo selection

### DIFF
--- a/api/routes/register-router.ts
+++ b/api/routes/register-router.ts
@@ -96,7 +96,7 @@ registerRouter.get('/:id/photos', async (req: Request, res: Response) => {
 		return res.status(404).send();
 	}
 
-	const photos = await photoService.getAllForPlace(parseInt(id));
+	const photos = await photoService.getAllForRegisterPlace(parseInt(id));
 
 	res.json({ data: photos });
 });
@@ -110,7 +110,7 @@ registerRouter.get('/:id/photos/:photoId', async (req: Request, res: Response) =
 	}
 
 	await photoService
-		.getFileById(photoId)
+		.getRegisterFileById(photoId)
 		.then(async (photo) => {
 			if (photo && photo.file) {
 				const t = await createThumbnail(photo.file);

--- a/api/services/photo-service.ts
+++ b/api/services/photo-service.ts
@@ -61,6 +61,7 @@ export class PhotoService {
 				this.on('PH.placeId', '=', 'place.id');
 			})
 			.where({ showInRegister: true })
+			.orderBy('PH.YRHPOrder', 'asc')
 			.catch((err) => {
 				console.error(err);
 				return new Array<Photo>();
@@ -71,6 +72,18 @@ export class PhotoService {
 		return db('photo')
 			.select<Photo>('file')
 			.where({ rowId: id })
+			.first()
+			.catch((err) => {
+				console.error(err);
+				return undefined;
+			});
+	}
+
+	async getRegisterFileById(id: string): Promise<Photo | undefined> {
+		return db('photo')
+			.select<Photo>('file')
+			.where({ rowId: id })
+			.where({ showInRegister: true })
 			.first()
 			.catch((err) => {
 				console.error(err);

--- a/api/services/place-service.ts
+++ b/api/services/place-service.ts
@@ -110,18 +110,19 @@ export class PlaceService {
 		return db('place')
 			.select([...REGISTER_FIELDS, 'PH.ThumbFile', 'PH.caption'])
 			.join('community', 'community.id', 'place.communityid')
-			.leftJoin('dbo.photo as PH', function () {
-				this.on('PH.PlaceId', '=', 'Place.Id')
-					/* The new line here */
-					.andOn(
-						'PH.DateCreated',
-						'=',
-						db.raw('(select min(PH.DateCreated) from dbo.photo as PH where PH.PlaceId = Place.Id)')
-					);
-			})
-			.where({ "place.showInRegister": true })
-			.whereNull('Place.deleted_at')
-			.orderBy('Place.Id')
+			.joinRaw(
+				`outer apply (
+					select top 1 photo.ThumbFile, photo.caption
+					from dbo.photo as photo
+					where photo.PlaceId = place.Id
+					AND photo.showInRegister = 1
+					AND photo.IsYRHPCoverImage = 1
+					ORDER by photo.YRHPOrder asc, photo.DateCreated asc, photo.Id asc
+				) as PH`
+			)
+			.where({ 'place.showInRegister': true })
+			.whereNull('place.deleted_at')
+			.orderBy('place.Id')
 			.offset(skip)
 			.limit(take);
 	}


### PR DESCRIPTION
Order register photos by YRHPOrder and add a register-specific file lookup for photo thumbnails. Update place register results to use the YRHP cover image with a deterministic fallback order.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
