### PR TITLE
Preserve EXIF orientation in thumbnails

### DIFF
--- a/api/utils/image.ts
+++ b/api/utils/image.ts
@@ -6,7 +6,9 @@ const THUMBNAIL_WIDTH = 672;
 const THUMBNAIL_HEIGHT = 448;
 
 export async function createThumbnail(input: Buffer): Promise<Buffer> {
-    return sharp(input).resize(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
+    return sharp(input)
+        .rotate() // auto-orient from EXIF before resizing, otherwise rotation is lost
+        .resize(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT)
         .jpeg({ quality: THUMBNAIL_JPEG_QUALITY })
         .toBuffer();
 }


### PR DESCRIPTION
Update thumbnail generation to call `sharp().rotate()` before resizing so images are auto-oriented from EXIF metadata. This prevents thumbnails from losing the original photo rotation.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
