### PR TITLE
Normalize photo subjects before saving

### DIFF
--- a/api/services/photo-batch-service.ts
+++ b/api/services/photo-batch-service.ts
@@ -4,6 +4,7 @@ import db from '@/db/db-client';
 
 import { QueryStatement, SortStatement } from './';
 import { PhotoBatch, PhotoBatchPhoto, PHOTO_BATCH_FIELDS } from '../data';
+import { normalizeSubjects } from '../utils/subjects';
 
 export class PhotoBatchService {
 	async getAll(skip: number, take: number): Promise<Array<any>> {
@@ -184,7 +185,7 @@ export class PhotoBatchService {
 	async updateBatch(id: string, item: PhotoBatch): Promise<PhotoBatch | undefined> {
 		return db('PhotoBatch')
 			.where({ id: id })
-			.update(item)
+			.update(normalizeSubjects(item))
 			.returning<PhotoBatch>(PHOTO_BATCH_FIELDS);
 	}
 

--- a/api/services/photo-service.ts
+++ b/api/services/photo-service.ts
@@ -4,6 +4,7 @@ import db from '@/db/db-client';
 
 import { QueryStatement, SortStatement } from './';
 import { Photo, PHOTO_FIELDS, SavedFilter } from '../data';
+import { normalizeSubjects } from '../utils/subjects';
 
 export class PhotoService {
 	async getAll(skip: number, take: number): Promise<Array<Photo>> {
@@ -115,11 +116,14 @@ export class PhotoService {
 	}
 
 	async addPhoto(item: Photo): Promise<Photo | undefined> {
-		return db('photo').insert(item).returning<Photo>(PHOTO_FIELDS);
+		return db('photo').insert(normalizeSubjects(item)).returning<Photo>(PHOTO_FIELDS);
 	}
 
 	async updatePhoto(id: string, item: Photo): Promise<Photo | undefined> {
-		return db('photo').where({ rowId: id }).update(item).returning<Photo>(PHOTO_FIELDS);
+		return db('photo')
+			.where({ rowId: id })
+			.update(normalizeSubjects(item))
+			.returning<Photo>(PHOTO_FIELDS);
 	}
 
 	async doSearch(

--- a/api/utils/subjects.ts
+++ b/api/utils/subjects.ts
@@ -1,0 +1,12 @@
+/**
+ * The subjects UI is a multi-select, so clients split the comma-delimited
+ * varchar(500) column into an array on load and send it back that way on save.
+ * Collapse it to a string before it reaches tedious, which rejects arrays.
+ */
+export function normalizeSubjects<T>(item: T): T {
+	const subjects = (item as any)?.subjects;
+
+	if (!Array.isArray(subjects)) return item;
+
+	return { ...item, subjects: subjects.length > 0 ? subjects.join(',') : null };
+}


### PR DESCRIPTION
Add a shared helper to collapse multi-select subject arrays into the comma-delimited string expected by the database, and use it for photo and photo batch inserts/updates.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
