### PR TITLE
Fix getAllForRegisterPlace query

### DIFF
--- a/api/services/photo-service.ts
+++ b/api/services/photo-service.ts
@@ -55,14 +55,11 @@ export class PhotoService {
 			});
 	}
 
-	async getAllForRegisterPlace(_id: number): Promise<Photo[]> {
-		return db('place')
+	async getAllForRegisterPlace(id: number): Promise<Photo[]> {
+		return db('photo')
 			.select<Photo[]>(PHOTO_FIELDS)
-			.leftJoin('dbo.photo as PH', function () {
-				this.on('PH.placeId', '=', 'place.id');
-			})
-			.where({ showInRegister: true })
-			.orderBy('PH.YRHPOrder', 'asc')
+			.where({ placeId: id, showInRegister: true })
+			.orderBy('yRHPOrder', 'asc')
 			.catch((err) => {
 				console.error(err);
 				return new Array<Photo>();


### PR DESCRIPTION
Simplify the query by querying the photo table directly instead of joining from place. Also fix the parameter name and column reference for ordering.

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
