### PR TITLE
Fixing Lat/Long data entry

### DIFF
--- a/api/routes/place-edits-router.ts
+++ b/api/routes/place-edits-router.ts
@@ -6,6 +6,7 @@ import { ReturnValidationErrors } from '../middleware';
 import { PlaceEditService } from '../services';
 import { UserRoles } from '../models';
 import { authorize } from '../middleware/authorization';
+import { coordinateBody } from '../utils/coordinates';
 
 export const placeEditsRouter = express.Router();
 const placeEditService = new PlaceEditService();
@@ -85,10 +86,10 @@ placeEditsRouter.post(
 		body('isPubliclyAccessible').isBoolean(),
 		body('jurisdiction').isInt(),
 		body('lAGroup').isString().optional({ nullable: true }),
-		body('latitude').isString().optional({ nullable: true }),
+		coordinateBody('latitude', 'latitude'),
 		body('locationComment').isString().optional({ nullable: true }),
 		body('locationContext').isString().optional({ nullable: true }),
-		body('longitude').isString().optional({ nullable: true }),
+		coordinateBody('longitude', 'longitude'),
 		body('lot').isString().optional({ nullable: true }),
 		body('names').isArray().optional({ nullable: true }),
 		body('nTSMapSheet').isString().optional({ nullable: true }),

--- a/api/routes/place-router.ts
+++ b/api/routes/place-router.ts
@@ -15,6 +15,7 @@ import PlacesController from '@/controllers/places-controller';
 import { PlacePolicy } from '@/policies';
 import { generatePDF } from '@/utils/pdf-generator';
 import { createThumbnail } from '@/utils/image';
+import { coordinateBody } from '@/utils/coordinates';
 import { Photo } from '@/data/photo-entities';
 
 const placeService = new PlaceService();
@@ -186,6 +187,8 @@ placeRouter.post(
 		body('doorCondition').isInt().bail().notEmpty(),
 		body('roofCondition').isInt().bail().notEmpty(),
 		body('coordinateDetermination').isInt().bail().notEmpty(),
+		coordinateBody('latitude', 'latitude'),
+		coordinateBody('longitude', 'longitude'),
 		body('isPubliclyAccessible').isBoolean().bail().notEmpty(),
 		body('showInRegister').isBoolean().bail().notEmpty(),
 	],
@@ -348,10 +351,10 @@ placeRouter.patch(
 		body('isPubliclyAccessible').isBoolean().optional(),
 		body('jurisdiction').isInt().optional(),
 		body('lAGroup').isString().optional({ nullable: true }),
-		body('latitude').isString().optional({ nullable: true }),
+		coordinateBody('latitude', 'latitude'),
 		body('locationComment').isString().optional({ nullable: true }),
 		body('locationContext').isString().optional({ nullable: true }),
-		body('longitude').isString().optional({ nullable: true }),
+		coordinateBody('longitude', 'longitude'),
 		body('lot').isString().optional({ nullable: true }),
 		body('names').isArray().optional({ nullable: true }),
 		body('nTSMapSheet').isString().optional({ nullable: true }),

--- a/api/utils/coordinates.ts
+++ b/api/utils/coordinates.ts
@@ -1,0 +1,248 @@
+import { body, ValidationChain } from 'express-validator';
+
+/**
+ * Strict parsing / formatting / validation for geographic coordinates.
+ *
+ * Server-side counterpart to `web/src/utils/coordinates.js` — the two must stay
+ * in step. Decimal degrees is the canonical stored form; the Place tables hold
+ * it as nvarchar, the newer tables as float, so `normalizeCoordinate` returns a
+ * canonical string that is safe for both.
+ *
+ * Parsing accepts decimal degrees (DD), degrees-decimal-minutes (DDM) and
+ * degrees-minutes-seconds (DMS). Anything else is an error rather than a
+ * best-effort guess — a silently mis-parsed coordinate puts a heritage site in
+ * the wrong place.
+ */
+
+export type CoordinateAxis = 'latitude' | 'longitude';
+
+interface AxisConfig {
+	label: string;
+	max: number;
+	positive: string;
+	negative: string;
+}
+
+export const AXES: Record<CoordinateAxis, AxisConfig> = {
+	latitude: { label: 'Latitude', max: 90, positive: 'N', negative: 'S' },
+	longitude: { label: 'Longitude', max: 180, positive: 'E', negative: 'W' },
+};
+
+export const DEFAULT_PRECISION = 6;
+
+/**
+ * Every record in this system is in the Yukon, which is entirely west of
+ * Greenwich, so a stored longitude is always negative. Downstream consumers
+ * (the CSW feed in particular) reject records where the sign varies, so an
+ * unsigned longitude is read as west rather than passed through, and an
+ * explicitly eastern one is an error.
+ */
+export const WESTERN_LONGITUDE_ONLY = true;
+
+export interface CoordinateParseResult {
+	ok: boolean;
+	empty: boolean;
+	value: number | null;
+	error: string | null;
+}
+
+function failure(error: string): CoordinateParseResult {
+	return { ok: false, empty: false, value: null, error };
+}
+
+function success(value: number): CoordinateParseResult {
+	return { ok: true, empty: false, value, error: null };
+}
+
+const EMPTY: CoordinateParseResult = { ok: true, empty: true, value: null, error: null };
+
+/**
+ * Force longitudes into the western hemisphere. An unsigned value is read as
+ * west; a value explicitly marked east is rejected rather than silently
+ * flipped, since that is a transposition or a typo, not a Yukon site.
+ */
+function applyHemisphereRule(
+	value: number,
+	axis: CoordinateAxis,
+	signExplicit: boolean
+): CoordinateParseResult {
+	if (!WESTERN_LONGITUDE_ONLY || axis !== 'longitude' || value <= 0) {
+		return success(value);
+	}
+
+	if (signExplicit) {
+		return failure('Longitude must be west of Greenwich (negative)');
+	}
+
+	return success(-value);
+}
+
+/**
+ * Replace the unicode variants clients paste in (from Word, ArcGIS, Google
+ * Maps) with their ascii equivalents so the tokenizer only sees one spelling.
+ */
+function canonicalize(text: string): string {
+	return text
+		.replace(/[′‘’]/g, "'")
+		.replace(/[″“”]/g, '"')
+		.replace(/[º°˚]/g, '°')
+		.replace(/[‐-―−]/g, '-')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Parse a coordinate in DD, DDM or DMS into decimal degrees. Blank input is
+ * `empty` and `ok` — required-ness is a separate concern.
+ */
+export function parseCoordinate(input: unknown, axis: CoordinateAxis): CoordinateParseResult {
+	const { label, max, positive, negative } = AXES[axis];
+
+	if (input === null || input === undefined) return EMPTY;
+
+	if (typeof input === 'number') {
+		if (!Number.isFinite(input)) return failure(`${label} must be a number`);
+		if (Math.abs(input) > max) return failure(`${label} must be between -${max} and ${max}`);
+		// A bare number carries no explicit sign intent, so it is subject to the
+		// western-longitude rule the same way unsigned text is.
+		return applyHemisphereRule(input, axis, false);
+	}
+
+	if (typeof input !== 'string') return failure(`${label} must be a number`);
+
+	let text = canonicalize(input);
+	if (text === '') return EMPTY;
+
+	// Hemisphere letter, leading or trailing. Reject the wrong axis outright:
+	// "60 W" as a latitude is a transposed pair, not a coordinate.
+	let hemisphere: string | null = null;
+	const hemisphereMatch = text.match(/^([nsew])\s*|\s*([nsew])$/i);
+	if (hemisphereMatch) {
+		hemisphere = (hemisphereMatch[1] || hemisphereMatch[2]).toUpperCase();
+		text = text.replace(hemisphereMatch[0], '').trim();
+		if (hemisphere !== positive && hemisphere !== negative) {
+			return failure(`${label} must use ${positive} or ${negative}, not ${hemisphere}`);
+		}
+	}
+
+	// A second hemisphere letter means two coordinates arrived in one field.
+	if (/[nsew]/i.test(text)) {
+		return failure(`Expected a single ${label.toLowerCase()} value`);
+	}
+
+	let negativeSign = false;
+	if (text.startsWith('-')) {
+		negativeSign = true;
+		text = text.slice(1).trim();
+	} else if (text.startsWith('+')) {
+		text = text.slice(1).trim();
+	}
+
+	if (negativeSign && hemisphere) {
+		return failure(`Use either a minus sign or ${hemisphere}, not both`);
+	}
+
+	// Degree/minute/second marks are separators; everything else must be digits.
+	const tokens = text
+		.replace(/[°'"]/g, ' ')
+		.trim()
+		.split(/\s+/)
+		.filter((token) => token !== '');
+
+	if (tokens.length === 0 || tokens.length > 3) {
+		return failure(`${label} is not a recognized coordinate`);
+	}
+
+	for (let i = 0; i < tokens.length; i += 1) {
+		// Only the smallest unit may be fractional — "60.5 30 00" is nonsense.
+		const pattern = i === tokens.length - 1 ? /^\d+(\.\d+)?$/ : /^\d+$/;
+		if (!pattern.test(tokens[i])) {
+			return failure(`${label} is not a recognized coordinate`);
+		}
+	}
+
+	const [degrees, minutes = 0, seconds = 0] = tokens.map(Number);
+
+	if (tokens.length > 1 && minutes >= 60) return failure('Minutes must be less than 60');
+	if (tokens.length > 2 && seconds >= 60) return failure('Seconds must be less than 60');
+
+	let value = degrees + minutes / 60 + seconds / 3600;
+	if (negativeSign || hemisphere === negative) value = -value;
+
+	if (Math.abs(value) > max) {
+		return failure(`${label} must be between -${max} and ${max}`);
+	}
+
+	return applyHemisphereRule(value, axis, negativeSign || hemisphere !== null);
+}
+
+export function isValidCoordinate(input: unknown, axis: CoordinateAxis): boolean {
+	return parseCoordinate(input, axis).ok;
+}
+
+/** Canonical decimal-degrees string; null for blank or unparseable input. */
+export function normalizeCoordinate(
+	input: unknown,
+	axis: CoordinateAxis,
+	precision = DEFAULT_PRECISION
+): string | null {
+	const result = parseCoordinate(input, axis);
+	if (!result.ok || result.empty || result.value === null) return null;
+
+	// Number() drops the trailing zeros toFixed() adds.
+	return String(Number(result.value.toFixed(precision)));
+}
+
+/** Decimal-degrees number; null for blank or unparseable input. */
+export function toDecimalDegrees(
+	input: unknown,
+	axis: CoordinateAxis,
+	precision = DEFAULT_PRECISION
+): number | null {
+	const normalized = normalizeCoordinate(input, axis, precision);
+	return normalized === null ? null : Number(normalized);
+}
+
+/** Human-readable DMS, e.g. `60° 43' 16.4" N`; null for blank/unparseable input. */
+export function formatDms(input: unknown, axis: CoordinateAxis): string | null {
+	const { positive, negative } = AXES[axis];
+	const result = parseCoordinate(input, axis);
+	if (!result.ok || result.empty || result.value === null) return null;
+
+	const hemisphere = result.value < 0 ? negative : positive;
+	const absolute = Math.abs(result.value);
+
+	let degrees = Math.floor(absolute);
+	let minutes = Math.floor((absolute - degrees) * 60);
+	let seconds = Number(((absolute - degrees - minutes / 60) * 3600).toFixed(1));
+
+	// Rounding seconds can tip them to 60.0; carry so we never print 60" or 60'.
+	if (seconds >= 60) {
+		seconds = 0;
+		minutes += 1;
+	}
+	if (minutes >= 60) {
+		minutes = 0;
+		degrees += 1;
+	}
+
+	return `${degrees}° ${String(minutes).padStart(2, '0')}' ${seconds
+		.toFixed(1)
+		.padStart(4, '0')}" ${hemisphere}`;
+}
+
+/**
+ * express-validator chain for an optional coordinate field: rejects anything
+ * unparseable and rewrites what is accepted into canonical decimal degrees, so
+ * services and the database only ever see the one format.
+ */
+export function coordinateBody(field: string, axis: CoordinateAxis): ValidationChain {
+	return body(field)
+		.optional({ nullable: true })
+		.custom((value) => {
+			const result = parseCoordinate(value, axis);
+			if (result.ok) return true;
+			throw new Error(result.error as string);
+		})
+		.customSanitizer((value) => normalizeCoordinate(value, axis));
+}

--- a/db/scripts/normalize_coordinates.sql
+++ b/db/scripts/normalize_coordinates.sql
@@ -1,0 +1,129 @@
+/*
+  Normalize stored latitude/longitude to the canonical form the app now writes.
+
+  Canonical form (matches api/utils/coordinates.ts and web/src/utils/coordinates.js):
+    - decimal degrees, no leading or trailing whitespace
+    - at most 6 decimal places, no trailing zeros, no leading '+'
+    - longitude always negative (every site is west of Greenwich)
+
+  Only dbo.Place and dbo.PlaceEdit store coordinates as nvarchar(256), so they
+  are the only ones that can carry stray whitespace or a non-numeric value. The
+  other tables are float and can only be wrong in sign — step 3.
+
+  RUN PART 1 FIRST. Rows it reports as unparseable are left untouched by the
+  updates and need a decision — they are the most likely source of the CSW
+  errors. Part 2 runs inside a transaction that ROLLBACKs by default; switch it
+  to COMMIT once the affected row counts look right.
+*/
+
+------------------------------------------------------------------------------
+-- Part 1: audit (read-only)
+------------------------------------------------------------------------------
+
+-- Values that will not parse as a number and so cannot be normalized here.
+SELECT 'Place' AS [Table], Id, YHSIId, Latitude, Longitude
+FROM dbo.Place
+WHERE (Latitude IS NOT NULL AND LTRIM(RTRIM(Latitude)) <> ''
+       AND TRY_CAST(LTRIM(RTRIM(Latitude)) AS decimal(12, 6)) IS NULL)
+   OR (Longitude IS NOT NULL AND LTRIM(RTRIM(Longitude)) <> ''
+       AND TRY_CAST(LTRIM(RTRIM(Longitude)) AS decimal(12, 6)) IS NULL)
+UNION ALL
+SELECT 'PlaceEdit', Id, YHSIId, Latitude, Longitude
+FROM dbo.PlaceEdit
+WHERE (Latitude IS NOT NULL AND LTRIM(RTRIM(Latitude)) <> ''
+       AND TRY_CAST(LTRIM(RTRIM(Latitude)) AS decimal(12, 6)) IS NULL)
+   OR (Longitude IS NOT NULL AND LTRIM(RTRIM(Longitude)) <> ''
+       AND TRY_CAST(LTRIM(RTRIM(Longitude)) AS decimal(12, 6)) IS NULL);
+
+-- Counts by problem, to sanity-check the update row counts below.
+SELECT
+	SUM(CASE WHEN Latitude <> LTRIM(RTRIM(Latitude))
+	          OR Longitude <> LTRIM(RTRIM(Longitude)) THEN 1 ELSE 0 END) AS HasWhitespace,
+	SUM(CASE WHEN TRY_CAST(Longitude AS decimal(12, 6)) > 0 THEN 1 ELSE 0 END) AS PositiveLongitude,
+	SUM(CASE WHEN TRY_CAST(Latitude AS decimal(12, 6)) IS NULL
+	          AND LTRIM(RTRIM(ISNULL(Latitude, ''))) <> '' THEN 1 ELSE 0 END) AS UnparseableLatitude,
+	SUM(CASE WHEN TRY_CAST(Longitude AS decimal(12, 6)) IS NULL
+	          AND LTRIM(RTRIM(ISNULL(Longitude, ''))) <> '' THEN 1 ELSE 0 END) AS UnparseableLongitude
+FROM dbo.Place;
+GO
+
+------------------------------------------------------------------------------
+-- Part 2: normalize
+------------------------------------------------------------------------------
+
+-- Canonicalize a decimal(12,6) into the app's string form: trailing zeros
+-- stripped, then a bare trailing '.' stripped (so 60.000000 -> 60).
+IF OBJECT_ID('dbo.fn_CanonicalCoordinate') IS NOT NULL
+	DROP FUNCTION dbo.fn_CanonicalCoordinate;
+GO
+CREATE FUNCTION dbo.fn_CanonicalCoordinate (@value decimal(12, 6))
+RETURNS nvarchar(50)
+AS
+BEGIN
+	IF @value IS NULL RETURN NULL;
+
+	DECLARE @text nvarchar(50) = CONVERT(nvarchar(50), @value);
+
+	-- Only trim zeros when there is a decimal point to trim toward, or "1200"
+	-- would lose its magnitude.
+	IF CHARINDEX('.', @text) > 0
+	BEGIN
+		SET @text = REVERSE(SUBSTRING(REVERSE(@text), PATINDEX('%[^0]%', REVERSE(@text)), LEN(@text)));
+		IF RIGHT(@text, 1) = '.' SET @text = LEFT(@text, LEN(@text) - 1);
+	END
+
+	RETURN @text;
+END
+GO
+
+BEGIN TRANSACTION;
+
+-- Step 1: dbo.Place / dbo.PlaceEdit (nvarchar) — trim, reformat, force west.
+-- Unparseable values cast to NULL, so each column is only rewritten when it
+-- parses; the audit above lists the ones this skips.
+UPDATE dbo.Place
+SET
+	Latitude = COALESCE(
+		dbo.fn_CanonicalCoordinate(TRY_CAST(LTRIM(RTRIM(Latitude)) AS decimal(12, 6))),
+		Latitude
+	),
+	Longitude = COALESCE(
+		dbo.fn_CanonicalCoordinate(-ABS(TRY_CAST(LTRIM(RTRIM(Longitude)) AS decimal(12, 6)))),
+		Longitude
+	)
+WHERE TRY_CAST(LTRIM(RTRIM(Latitude)) AS decimal(12, 6)) IS NOT NULL
+   OR TRY_CAST(LTRIM(RTRIM(Longitude)) AS decimal(12, 6)) IS NOT NULL;
+
+UPDATE dbo.PlaceEdit
+SET
+	Latitude = COALESCE(
+		dbo.fn_CanonicalCoordinate(TRY_CAST(LTRIM(RTRIM(Latitude)) AS decimal(12, 6))),
+		Latitude
+	),
+	Longitude = COALESCE(
+		dbo.fn_CanonicalCoordinate(-ABS(TRY_CAST(LTRIM(RTRIM(Longitude)) AS decimal(12, 6)))),
+		Longitude
+	)
+WHERE TRY_CAST(LTRIM(RTRIM(Latitude)) AS decimal(12, 6)) IS NOT NULL
+   OR TRY_CAST(LTRIM(RTRIM(Longitude)) AS decimal(12, 6)) IS NOT NULL;
+
+-- Step 2: float columns — sign only. Guarded, since not every deployment has
+-- every one of these tables.
+IF OBJECT_ID('Place.Place') IS NOT NULL
+	UPDATE [Place].[Place] SET Longitude = -ABS(Longitude) WHERE Longitude > 0;
+
+IF OBJECT_ID('InterpretiveSite.Sites') IS NOT NULL
+	UPDATE [InterpretiveSite].[Sites] SET Longitude = -ABS(Longitude) WHERE Longitude > 0;
+
+IF OBJECT_ID('Burial.CemetaryLookup') IS NOT NULL
+	UPDATE [Burial].[CemetaryLookup] SET Longitude = -ABS(Longitude) WHERE Longitude > 0;
+
+IF OBJECT_ID('dbo.clate') IS NOT NULL
+	UPDATE [dbo].[clate] SET Longitude = -ABS(Longitude) WHERE Longitude > 0;
+
+-- Change to COMMIT TRANSACTION once the affected row counts have been reviewed.
+ROLLBACK TRANSACTION;
+GO
+
+DROP FUNCTION dbo.fn_CanonicalCoordinate;
+GO

--- a/web/src/components/Administration/LookupTableManagement/Cemetary/AddDialog.vue
+++ b/web/src/components/Administration/LookupTableManagement/Cemetary/AddDialog.vue
@@ -14,8 +14,10 @@
           <v-text-field label="Community" v-model="community" outlined dense></v-text-field>
           <v-text-field label="Address" v-model="address" outlined dense></v-text-field>
           <v-text-field label="Notes" v-model="notes" outlined dense></v-text-field>
-          <v-text-field label="Latitude" v-model="latitude" outlined dense></v-text-field>
-          <v-text-field label="Longitude" v-model="longitude" outlined dense></v-text-field>
+          <CoordinateField axis="latitude" v-model="latitude" numeric warn-outside-yukon
+            :paired-longitude="longitude" outlined dense />
+          <CoordinateField axis="longitude" v-model="longitude" numeric warn-outside-yukon
+            :paired-latitude="latitude" outlined dense />
         </v-form>
       </v-card-text>
       <v-card-actions class="px-6">
@@ -31,8 +33,10 @@
 
 <script>
 import catalogs from '../../../../controllers/catalogs';
+import CoordinateField from '@/components/CoordinateField.vue';
 
 export default {
+  components: { CoordinateField },
   data: () => ({
     dialog: false,
     valid: false,
@@ -40,8 +44,8 @@ export default {
     community: '',
     address: '',
     notes: '',
-    latitude: '',
-    longitude: '',
+    latitude: null,
+    longitude: null,
     saving: false,
   }),
   methods: {
@@ -73,8 +77,8 @@ export default {
       this.community = '';
       this.address = '';
       this.notes = '';
-      this.latitude = '';
-      this.longitude = '';
+      this.latitude = null;
+      this.longitude = null;
       this.$refs.form && this.$refs.form.reset();
     },
   },

--- a/web/src/components/Administration/LookupTableManagement/Cemetary/EditDialog.vue
+++ b/web/src/components/Administration/LookupTableManagement/Cemetary/EditDialog.vue
@@ -10,8 +10,10 @@
             <v-text-field label="Community" v-model="community" outlined dense></v-text-field>
             <v-text-field label="Address" v-model="address" outlined dense></v-text-field>
             <v-text-field label="Notes" v-model="notes" outlined dense></v-text-field>
-            <v-text-field label="Latitude" v-model="latitude" outlined dense></v-text-field>
-            <v-text-field label="Longitude" v-model="longitude" outlined dense></v-text-field>
+            <CoordinateField axis="latitude" v-model="latitude" numeric warn-outside-yukon
+              :paired-longitude="longitude" outlined dense />
+            <CoordinateField axis="longitude" v-model="longitude" numeric warn-outside-yukon
+              :paired-latitude="latitude" outlined dense />
           </v-form>
         </v-card-text>
         <v-card-actions class="px-6">
@@ -27,9 +29,12 @@
 </template>
 
 <script>
+import { isNil } from 'lodash';
 import catalogs from '../../../../controllers/catalogs';
+import CoordinateField from '@/components/CoordinateField.vue';
 
 export default {
+  components: { CoordinateField },
   props: ['dialog', 'item'],
   data: () => ({
     valid: false,
@@ -37,8 +42,8 @@ export default {
     community: '',
     address: '',
     notes: '',
-    latitude: '',
-    longitude: '',
+    latitude: null,
+    longitude: null,
     saving: false,
   }),
   watch: {
@@ -49,8 +54,9 @@ export default {
           this.community = val.Community || '';
           this.address = val.Address || '';
           this.notes = val.Notes || '';
-          this.latitude = val.Latitude || '';
-          this.longitude = val.Longitude || '';
+          // Not `|| null` — a real 0 must survive.
+          this.latitude = isNil(val.Latitude) ? null : val.Latitude;
+          this.longitude = isNil(val.Longitude) ? null : val.Longitude;
         }
       },
       immediate: true,

--- a/web/src/components/CoordinateField.vue
+++ b/web/src/components/CoordinateField.vue
@@ -1,0 +1,197 @@
+<template>
+	<v-text-field
+		v-model="display"
+		v-bind="$attrs"
+		:label="fieldLabel"
+		:rules="fieldRules"
+		:hint="fieldHint"
+		:persistent-hint="persistentHint"
+		v-on="listeners"
+		@input="onInput"
+		@blur="onBlur"
+	/>
+</template>
+
+<script>
+import {
+	coordinateRule,
+	formatCoordinate,
+	formatDms,
+	isNearYukon,
+	parseCoordinate,
+	yukonRange,
+	AXES,
+	DEFAULT_PRECISION,
+	YUKON_BUFFER_DEGREES,
+} from '@/utils/coordinates';
+
+/**
+ * The standard latitude/longitude input.
+ *
+ * Accepts decimal degrees, degrees-decimal-minutes or degrees-minutes-seconds
+ * and normalizes to decimal degrees; see `@/utils/coordinates`. Use this
+ * instead of a bare v-text-field anywhere a coordinate is entered so the
+ * parsing and error messages stay consistent.
+ *
+ * Emits a normalized decimal-degrees string (or Number, with `numeric`) as
+ * soon as the input parses, and the raw text while it does not — the rule and
+ * the API-side validator are what keep unparseable text from being saved.
+ */
+export default {
+	name: 'CoordinateField',
+	inheritAttrs: false,
+	props: {
+		value: {
+			type: [String, Number],
+			default: null,
+		},
+		axis: {
+			type: String,
+			required: true,
+			validator: (v) => Object.keys(AXES).includes(v),
+		},
+		label: {
+			type: String,
+			default: null,
+		},
+		required: {
+			type: Boolean,
+			default: false,
+		},
+		/** Emit a Number rather than a normalized string (for float columns). */
+		numeric: {
+			type: Boolean,
+			default: false,
+		},
+		/** Decimal places kept when normalizing — ~0.1 m at Yukon latitudes. */
+		precision: {
+			type: Number,
+			default: DEFAULT_PRECISION,
+		},
+		/** Show a non-blocking hint when the point falls outside the territory. */
+		warnOutsideYukon: {
+			type: Boolean,
+			default: false,
+		},
+		/** Degrees of slack allowed around the territory before warning. */
+		yukonBuffer: {
+			type: Number,
+			default: YUKON_BUFFER_DEGREES,
+		},
+		/** Latitude to pair with, so the Yukon check has both axes. */
+		pairedLatitude: {
+			type: [String, Number],
+			default: null,
+		},
+		/** Longitude to pair with, so the Yukon check has both axes. */
+		pairedLongitude: {
+			type: [String, Number],
+			default: null,
+		},
+		rules: {
+			type: Array,
+			default: () => [],
+		},
+	},
+	data() {
+		return {
+			display: this.value === null || this.value === undefined ? '' : String(this.value),
+		};
+	},
+	computed: {
+		// `input` and `blur` are handled here; anything else passes through.
+		listeners() {
+			// eslint-disable-next-line no-unused-vars
+			const { input, blur, ...rest } = this.$listeners;
+			return rest;
+		},
+		fieldLabel() {
+			return this.label || AXES[this.axis].label;
+		},
+		fieldRules() {
+			return [coordinateRule(this.axis, { required: this.required }), ...this.rules];
+		},
+		parsed() {
+			return parseCoordinate(this.display, this.axis);
+		},
+		/**
+		 * Echo the DMS equivalent so an operator can eyeball that a pasted value
+		 * landed where they expected, and flag points outside the territory.
+		 */
+		fieldHint() {
+			if (!this.parsed.ok || this.parsed.empty) return undefined;
+
+			const dms = formatDms(this.parsed.value, this.axis);
+			if (this.isFarFromYukon) {
+				const { min, max } = yukonRange(this.axis, this.yukonBuffer);
+				return `${dms} — well outside Yukon, ensure this value is between ${min} and ${max}`;
+			}
+			return dms;
+		},
+		persistentHint() {
+			return this.isFarFromYukon;
+		},
+		isFarFromYukon() {
+			if (!this.warnOutsideYukon) return false;
+
+			const latitude = parseCoordinate(
+				this.axis === 'latitude' ? this.display : this.pairedLatitude,
+				'latitude'
+			);
+			const longitude = parseCoordinate(
+				this.axis === 'longitude' ? this.display : this.pairedLongitude,
+				'longitude'
+			);
+			// Only meaningful once both axes are present and valid.
+			if (!latitude.ok || latitude.empty || !longitude.ok || longitude.empty) {
+				return false;
+			}
+
+			return !isNearYukon(latitude.value, longitude.value, this.yukonBuffer);
+		},
+	},
+	watch: {
+		value(next) {
+			// Ignore the echo of our own emit so normalization does not rewrite
+			// the field out from under someone mid-keystroke.
+			const incoming = parseCoordinate(next, this.axis);
+			const current = this.parsed;
+			if (incoming.ok && current.ok && incoming.value === current.value) return;
+
+			this.display = next === null || next === undefined ? '' : String(next);
+		},
+	},
+	methods: {
+		emitValue(text) {
+			const result = parseCoordinate(text, this.axis);
+
+			if (result.empty) {
+				this.$emit('input', null);
+				return;
+			}
+			if (!result.ok) {
+				// Keep the raw text so the parent sees the field as dirty; the rule
+				// blocks the save.
+				this.$emit('input', text);
+				return;
+			}
+
+			const normalized = formatCoordinate(result.value, this.axis, this.precision);
+			this.$emit('input', this.numeric ? Number(normalized) : normalized);
+		},
+		onInput(text) {
+			this.display = text;
+			this.emitValue(text);
+		},
+		onBlur(event) {
+			// Rewrite what is on screen into the canonical form.
+			const normalized = formatCoordinate(this.display, this.axis, this.precision);
+			if (normalized !== null) {
+				this.display = normalized;
+			}
+			this.emitValue(this.display);
+			this.$emit('blur', event);
+		},
+	},
+};
+</script>

--- a/web/src/components/Sites/SiteChangeRequest.vue
+++ b/web/src/components/Sites/SiteChangeRequest.vue
@@ -113,6 +113,7 @@ import ConstructionPeriodsViewer from '@/components/Sites/site-change-request/Co
 import ContactsViewer from '@/components/Sites/site-change-request/ContactsViewer';
 import ContributingResourceTypesSelect from '@/components/Sites/site-forms/ContributingResourceTypesSelect';
 import CoordinateDeterminationTypesSelect from '@/components/Sites/site-forms/CoordinateDeterminationTypesSelect';
+import CoordinateField from '@/components/CoordinateField';
 import DatesViewer from '@/components/Sites/site-change-request/DatesViewer';
 import DescriptionsViewer from '@/components/Sites/site-change-request/DescriptionsViewer';
 import DesignationTypesSelect from '@/components/Sites/site-forms/DesignationTypesSelect';
@@ -248,32 +249,16 @@ const FIELD_TYPES = Object.freeze([
 	},
 	{
 		key: 'latitude',
-		type: 'v-text-field',
+		type: CoordinateField,
 		fieldAttrs: {
-			label: 'Latitude',
-			rules: [
-				(v) =>
-					!v ||
-					(/^-?\d+(\.\d+)?$/.test(String(v).trim()) &&
-						Number(v) >= -90 &&
-						Number(v) <= 90) ||
-					'Latitude must be a number between -90 and 90',
-			],
+			axis: 'latitude',
 		},
 	},
 	{
 		key: 'longitude',
-		type: 'v-text-field',
+		type: CoordinateField,
 		fieldAttrs: {
-			label: 'Longitude',
-			rules: [
-				(v) =>
-					!v ||
-					(/^-?\d+(\.\d+)?$/.test(String(v).trim()) &&
-						Number(v) >= -180 &&
-						Number(v) <= 180) ||
-					'Longitude must be a number between -180 and 180',
-			],
+			axis: 'longitude',
 		},
 	},
 	{

--- a/web/src/components/Sites/SiteCreate.vue
+++ b/web/src/components/Sites/SiteCreate.vue
@@ -68,12 +68,14 @@
 							</v-col>
 
 							<v-col cols="6" class="pb-0">
-								<v-text-field v-model="place.latitude" dense outlined label="Latitude"
-									background-color="white" :rules="requiredRules" />
+								<CoordinateField v-model="place.latitude" axis="latitude" dense outlined
+									background-color="white" required warn-outside-yukon
+									:paired-longitude="place.longitude" />
 							</v-col>
 							<v-col cols="6" class="pb-0">
-								<v-text-field v-model="place.longitude" dense outlined label="Longitude"
-									background-color="white" :rules="requiredRules" />
+								<CoordinateField v-model="place.longitude" axis="longitude" dense outlined
+									background-color="white" required warn-outside-yukon
+									:paired-latitude="place.latitude" />
 							</v-col>
 
 							<v-col>
@@ -110,10 +112,12 @@ import CategoryTypesSelect from './site-forms/CategoryTypesSelect.vue';
 import CommunitySelect from './site-forms/CommunitySelect.vue';
 import SiteStatusTypesSelect from './site-forms/SiteStatusTypesSelect.vue';
 import CoordinateDeterminationTypesSelect from './site-forms/CoordinateDeterminationTypesSelect.vue';
+import CoordinateField from '@/components/CoordinateField.vue';
 
 export default {
 	name: 'SiteCreate',
 	components: {
+		CoordinateField,
 		ConditionTypesSelect,
 		JurisdictionTypeSelect,
 		OwnerConsentTypeSelect,

--- a/web/src/components/Sites/SitesForms/Location.vue
+++ b/web/src/components/Sites/SitesForms/Location.vue
@@ -105,19 +105,23 @@
 					></v-textarea>
 				</div>
 				<div class="col-md-6">
-					<v-text-field
+					<CoordinateField
 						dense
 						outlined
+						axis="latitude"
 						v-model="fields.latitude"
-						label="Latitude"
-					></v-text-field>
+						warn-outside-yukon
+						:paired-longitude="fields.longitude"
+					/>
 
-					<v-text-field
+					<CoordinateField
 						dense
 						outlined
+						axis="longitude"
 						v-model="fields.longitude"
-						label="Longitude"
-					></v-text-field>
+						warn-outside-yukon
+						:paired-latitude="fields.latitude"
+					/>
 					<v-select
 						dense
 						outlined
@@ -196,9 +200,11 @@
 import axios from 'axios';
 import store from '../../../store';
 import { COMMUNITY_URL, PLACE_URL, STATIC_URL } from '../../../urls';
+import CoordinateField from '@/components/CoordinateField.vue';
 /* Important, field data that was not found on the swaggerhub api docs provided was assumed to be in development, hence, some placeholder variables were created */
 export default {
 	name: 'formLocation',
+	components: { CoordinateField },
 	data: () => ({
 		valid: false,
 		loadedId: -1,

--- a/web/src/components/Sites/site-forms/Location.vue
+++ b/web/src/components/Sites/site-forms/Location.vue
@@ -109,22 +109,24 @@
 					/>
 				</v-col>
 				<v-col cols="6">
-					<v-text-field
+					<CoordinateField
 						v-model="place.latitude"
+						axis="latitude"
 						dense
 						outlined
-						label="Latitude"
 						:readonly="!isEditing"
-						:rules="latitudeRules"
+						warn-outside-yukon
+						:paired-longitude="place.longitude"
 					/>
 
-					<v-text-field
+					<CoordinateField
 						v-model="place.longitude"
+						axis="longitude"
 						dense
 						outlined
-						label="Longitude"
 						:readonly="!isEditing"
-						:rules="longitudeRules"
+						warn-outside-yukon
+						:paired-latitude="place.latitude"
 					/>
 					<CoordinateDeterminationTypesSelect
 						v-model="place.coordinateDetermination"
@@ -201,35 +203,24 @@ import { pick } from 'lodash';
 
 import CommunitySelect from '@/components/Sites/site-forms/CommunitySelect';
 import CoordinateDeterminationTypesSelect from '@/components/Sites/site-forms/CoordinateDeterminationTypesSelect';
+import CoordinateField from '@/components/CoordinateField';
 import NtsMapSheetSelect from '@/components/Sites/site-forms/NtsMapSheetSelect';
 
 export default {
 	name: 'Location',
-	components: { CommunitySelect, CoordinateDeterminationTypesSelect, NtsMapSheetSelect },
+	components: {
+		CommunitySelect,
+		CoordinateDeterminationTypesSelect,
+		CoordinateField,
+		NtsMapSheetSelect,
+	},
 	props: {
 		placeId: {
 			type: [Number, String],
 			required: true,
 		},
 	},
-	data: () => ({
-		latitudeRules: [
-			(v) =>
-				!v ||
-				(/^-?\d+(\.\d+)?$/.test(String(v).trim()) &&
-					Number(v) >= -90 &&
-					Number(v) <= 90) ||
-				'Latitude must be a number between -90 and 90',
-		],
-		longitudeRules: [
-			(v) =>
-				!v ||
-				(/^-?\d+(\.\d+)?$/.test(String(v).trim()) &&
-					Number(v) >= -180 &&
-					Number(v) <= 180) ||
-				'Longitude must be a number between -180 and 180',
-		],
-	}),
+	data: () => ({}),
 	computed: {
 		...mapGetters({
 			place: 'places/place',

--- a/web/src/utils/coordinates.js
+++ b/web/src/utils/coordinates.js
@@ -1,0 +1,348 @@
+/**
+ * Strict parsing / formatting / validation for geographic coordinates.
+ *
+ * Decimal degrees is the canonical form: it is what every table in the schema
+ * stores and what Leaflet/ESRI expect. Operators paste coordinates in a mix of
+ * formats though, so parsing accepts decimal degrees (DD), degrees-decimal-
+ * minutes (DDM) and degrees-minutes-seconds (DMS), and normalizes to DD.
+ *
+ * Parsing is deliberately strict: anything that is not unambiguously one of
+ * those three forms is an error rather than a best-effort guess. A silently
+ * mis-parsed coordinate puts a heritage site in the wrong place.
+ */
+
+import pointInPolygon from 'point-in-polygon';
+import { yukonPolygon } from '@/misc/yukon_territory_polygon';
+
+export const AXES = {
+	latitude: {
+		key: 'latitude',
+		label: 'Latitude',
+		max: 90,
+		positive: 'N',
+		negative: 'S',
+	},
+	longitude: {
+		key: 'longitude',
+		label: 'Longitude',
+		max: 180,
+		positive: 'E',
+		negative: 'W',
+	},
+};
+
+export const DEFAULT_PRECISION = 6;
+
+/**
+ * Every record in this system is in the Yukon, which is entirely west of
+ * Greenwich, so a stored longitude is always negative. Downstream consumers
+ * (the CSW feed in particular) reject records where the sign varies, so an
+ * unsigned longitude is read as west rather than passed through, and an
+ * explicitly eastern one is an error.
+ */
+export const WESTERN_LONGITUDE_ONLY = true;
+
+function axisConfig(axis) {
+	const config = AXES[axis];
+	if (!config) {
+		throw new Error(`Unknown coordinate axis "${axis}"`);
+	}
+	return config;
+}
+
+function failure(error) {
+	return { ok: false, empty: false, value: null, error };
+}
+
+function success(value) {
+	return { ok: true, empty: false, value, error: null };
+}
+
+/**
+ * Force longitudes into the western hemisphere. An unsigned value is read as
+ * west; a value the operator explicitly marked east is rejected rather than
+ * silently flipped, since that is a transposition or a typo, not a Yukon site.
+ */
+function applyHemisphereRule(value, axis, signExplicit) {
+	if (!WESTERN_LONGITUDE_ONLY || axis !== 'longitude' || value <= 0) {
+		return success(value);
+	}
+
+	if (signExplicit) {
+		return failure('Longitude must be west of Greenwich (negative)');
+	}
+
+	return success(-value);
+}
+
+/**
+ * Replace the unicode variants operators paste in (from Word, ArcGIS, Google
+ * Maps) with their ascii equivalents so the tokenizer only sees one spelling.
+ */
+function canonicalize(text) {
+	return text
+		.replace(/[′‘’]/g, "'") // prime, curly single quotes
+		.replace(/[″“”]/g, '"') // double prime, curly double quotes
+		.replace(/[º°˚]/g, '°') // masculine ordinal, ring above
+		.replace(/[‐-―−]/g, '-') // dashes, unicode minus
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Parse a coordinate in DD, DDM or DMS into decimal degrees.
+ *
+ * @param {string|number|null|undefined} input
+ * @param {'latitude'|'longitude'} axis
+ * @returns {{ok: boolean, empty: boolean, value: number|null, error: string|null}}
+ *   `empty` is true (and `ok` true) for blank input — required-ness is a
+ *   separate concern, see `coordinateRule`.
+ */
+export function parseCoordinate(input, axis) {
+	const { label, max, positive, negative } = axisConfig(axis);
+
+	if (input === null || input === undefined) {
+		return { ok: true, empty: true, value: null, error: null };
+	}
+
+	if (typeof input === 'number') {
+		if (!Number.isFinite(input)) {
+			return failure(`${label} must be a number`);
+		}
+		if (Math.abs(input) > max) {
+			return failure(`${label} must be between -${max} and ${max}`);
+		}
+		// A bare number carries no explicit sign intent, so it is subject to the
+		// western-longitude rule the same way unsigned text is.
+		return applyHemisphereRule(input, axis, false);
+	}
+
+	if (typeof input !== 'string') {
+		return failure(`${label} must be a number`);
+	}
+
+	let text = canonicalize(input);
+	if (text === '') {
+		return { ok: true, empty: true, value: null, error: null };
+	}
+
+	// Hemisphere letter, leading or trailing. Reject the wrong axis outright:
+	// "60 W" as a latitude is a transposed pair, not a coordinate.
+	let hemisphere = null;
+	const hemisphereMatch = text.match(/^([nsew])\s*|\s*([nsew])$/i);
+	if (hemisphereMatch) {
+		hemisphere = (hemisphereMatch[1] || hemisphereMatch[2]).toUpperCase();
+		text = text.replace(hemisphereMatch[0], '').trim();
+		if (hemisphere !== positive && hemisphere !== negative) {
+			return failure(
+				`${label} must use ${positive} or ${negative}, not ${hemisphere}`
+			);
+		}
+	}
+
+	// A second hemisphere letter means two coordinates were pasted into one field.
+	if (/[nsew]/i.test(text)) {
+		return failure(`Enter a single ${label.toLowerCase()} value`);
+	}
+
+	let negativeSign = false;
+	if (text.startsWith('-')) {
+		negativeSign = true;
+		text = text.slice(1).trim();
+	} else if (text.startsWith('+')) {
+		text = text.slice(1).trim();
+	}
+
+	if (negativeSign && hemisphere) {
+		return failure(`Use either a minus sign or ${hemisphere}, not both`);
+	}
+
+	// Degree/minute/second marks are separators; everything else must be digits.
+	const tokens = text
+		.replace(/[°'"]/g, ' ')
+		.trim()
+		.split(/\s+/)
+		.filter((token) => token !== '');
+
+	if (tokens.length === 0 || tokens.length > 3) {
+		return failure(`${label} is not a recognized coordinate`);
+	}
+
+	for (let i = 0; i < tokens.length; i += 1) {
+		const isLast = i === tokens.length - 1;
+		// Only the smallest unit may be fractional — "60.5 30 00" is nonsense.
+		const pattern = isLast ? /^\d+(\.\d+)?$/ : /^\d+$/;
+		if (!pattern.test(tokens[i])) {
+			return failure(`${label} is not a recognized coordinate`);
+		}
+	}
+
+	const [degrees, minutes = '0', seconds = '0'] = tokens.map(Number);
+
+	if (tokens.length > 1 && minutes >= 60) {
+		return failure('Minutes must be less than 60');
+	}
+	if (tokens.length > 2 && seconds >= 60) {
+		return failure('Seconds must be less than 60');
+	}
+
+	let value = degrees + minutes / 60 + seconds / 3600;
+	if (negativeSign || hemisphere === negative) {
+		value = -value;
+	}
+
+	if (Math.abs(value) > max) {
+		return failure(`${label} must be between -${max} and ${max}`);
+	}
+
+	return applyHemisphereRule(value, axis, negativeSign || hemisphere !== null);
+}
+
+/**
+ * Normalized decimal-degrees string, suitable for storing and for round-
+ * tripping through the `nvarchar` Place columns. Returns null for blank or
+ * unparseable input.
+ */
+export function formatCoordinate(input, axis, precision = DEFAULT_PRECISION) {
+	const result = parseCoordinate(input, axis);
+	if (!result.ok || result.empty) return null;
+
+	// Number() drops the trailing zeros toFixed() adds.
+	return String(Number(result.value.toFixed(precision)));
+}
+
+/** Decimal-degrees number, or null for blank/unparseable input. */
+export function toDecimalDegrees(input, axis, precision = DEFAULT_PRECISION) {
+	const result = parseCoordinate(input, axis);
+	if (!result.ok || result.empty) return null;
+
+	return Number(result.value.toFixed(precision));
+}
+
+/** Human-readable DMS, e.g. `60° 43' 16.4" N`. Null for blank/unparseable input. */
+export function formatDms(input, axis) {
+	const { positive, negative } = axisConfig(axis);
+	const result = parseCoordinate(input, axis);
+	if (!result.ok || result.empty) return null;
+
+	const hemisphere = result.value < 0 ? negative : positive;
+	const absolute = Math.abs(result.value);
+
+	let degrees = Math.floor(absolute);
+	let minutes = Math.floor((absolute - degrees) * 60);
+	let seconds = Number(((absolute - degrees - minutes / 60) * 3600).toFixed(1));
+
+	// Rounding seconds can tip them to 60.0; carry so we never print 60" or 60'.
+	if (seconds >= 60) {
+		seconds = 0;
+		minutes += 1;
+	}
+	if (minutes >= 60) {
+		minutes = 0;
+		degrees += 1;
+	}
+
+	const paddedSeconds = seconds.toFixed(1).padStart(4, '0');
+	return `${degrees}° ${String(minutes).padStart(2, '0')}' ${paddedSeconds}" ${hemisphere}`;
+}
+
+/**
+ * How far outside the territory boundary a point may sit before it is flagged.
+ * Sites are recorded up to the border and a little past it — a survey point on
+ * the Alaska or NWT side of a boundary site is legitimate — so the check is
+ * deliberately loose. One degree is roughly 111 km north-south and ~50 km
+ * east-west at Yukon latitudes.
+ */
+export const YUKON_BUFFER_DEGREES = 1;
+
+let yukonBounds = null;
+
+function boundsOfYukon() {
+	if (yukonBounds) return yukonBounds;
+
+	yukonBounds = yukonPolygon.latlngs.reduce(
+		(bounds, [latitude, longitude]) => ({
+			minLatitude: Math.min(bounds.minLatitude, latitude),
+			maxLatitude: Math.max(bounds.maxLatitude, latitude),
+			minLongitude: Math.min(bounds.minLongitude, longitude),
+			maxLongitude: Math.max(bounds.maxLongitude, longitude),
+		}),
+		{
+			minLatitude: Infinity,
+			maxLatitude: -Infinity,
+			minLongitude: Infinity,
+			maxLongitude: -Infinity,
+		}
+	);
+
+	return yukonBounds;
+}
+
+/**
+ * True when the point is inside the territory, or within `buffer` degrees of
+ * its extent. Used for a soft warning only — it never blocks a save, since the
+ * boundary is not the authority on whether a record is valid.
+ */
+export function isNearYukon(latitude, longitude, buffer = YUKON_BUFFER_DEGREES) {
+	if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return true;
+
+	if (pointInPolygon([latitude, longitude], yukonPolygon.latlngs)) return true;
+
+	const bounds = boundsOfYukon();
+	return (
+		latitude >= bounds.minLatitude - buffer &&
+		latitude <= bounds.maxLatitude + buffer &&
+		longitude >= bounds.minLongitude - buffer &&
+		longitude <= bounds.maxLongitude + buffer
+	);
+}
+
+/**
+ * The buffered min/max for one axis, as the strings to show an operator.
+ *
+ * Rounded outward — floor the minimum, ceil the maximum — so a value inside the
+ * range this reports can never be the one being warned about.
+ */
+export function yukonRange(axis, buffer = YUKON_BUFFER_DEGREES, decimals = 2) {
+	const bounds = boundsOfYukon();
+	const factor = 10 ** decimals;
+	const [min, max] =
+		axis === 'latitude'
+			? [bounds.minLatitude - buffer, bounds.maxLatitude + buffer]
+			: [bounds.minLongitude - buffer, bounds.maxLongitude + buffer];
+
+	return {
+		min: (Math.floor(min * factor) / factor).toFixed(decimals),
+		max: (Math.ceil(max * factor) / factor).toFixed(decimals),
+	};
+}
+
+/**
+ * Vuetify rule factory. Blank passes unless `required` — presence and format
+ * are separate concerns so callers can compose them.
+ */
+export function coordinateRule(axis, { required = false } = {}) {
+	const { label } = axisConfig(axis);
+
+	return (v) => {
+		const result = parseCoordinate(v, axis);
+		if (result.empty) {
+			return required ? `${label} is required` : true;
+		}
+		return result.ok || result.error;
+	};
+}
+
+export default {
+	AXES,
+	DEFAULT_PRECISION,
+	WESTERN_LONGITUDE_ONLY,
+	YUKON_BUFFER_DEGREES,
+	parseCoordinate,
+	formatCoordinate,
+	toDecimalDegrees,
+	formatDms,
+	isNearYukon,
+	yukonRange,
+	coordinateRule,
+};

--- a/web/src/utils/validators/index.js
+++ b/web/src/utils/validators/index.js
@@ -1,1 +1,2 @@
 export { required } from "./required"
+export { coordinateRule } from "../coordinates"


### PR DESCRIPTION
Add a standard coordinate control

Lat/long were entered in several places with no shared handling: three copy-pasted regex rules on the Sites forms, nothing at all on the create form or the Cemetery dialogs, and `isString().optional()` on the API. The CSW feed rejects records whose formatting varies, so stored values now have one canonical form.

Canonical form is decimal degrees, trimmed, at most 6 decimal places with no trailing zeros, and longitude always negative. Parsing accepts DD, DDM and DMS and normalizes; it is strict, so an unrecognized value is an error rather than a best-effort guess. An unsigned longitude is read as west; an explicitly eastern one is rejected as a transposition.

CoordinateField replaces the bare v-text-fields, and coordinateBody validates and sanitizes on the API so services only ever see the one format. The out-of-Yukon check is a soft warning with a 1 degree buffer, since border sites are legitimate.

Existing rows are not canonical yet; db/scripts/normalize_coordinates.sql audits and fixes them, and has not been run.


@

Fixes TODO

Relates to:

- TODO

# Context

TODO

# Implementation

TODO

# Screenshots

TODO

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4.
