### PR TITLE
Register Updates

### DIFF
--- a/api/routes/register-router.ts
+++ b/api/routes/register-router.ts
@@ -63,6 +63,8 @@ registerRouter.get('/:id', async (req: Request, res: Response) => {
 	data.descBoundFr = '';
 	data.additionalInfoEn = '';
 	data.additionalInfoFr = '';
+	data.culturalHistoryEn = '';
+	data.culturalHistoryFr = '';
 
 	const descs = await descriptionService.getForPlace(parseInt(id));
 
@@ -82,6 +84,9 @@ registerRouter.get('/:id', async (req: Request, res: Response) => {
 		} else if (desc.type == 30) {
 			data.additionalInfoEn = desc.descriptionText;
 			data.additionalInfoFr = desc.fR_DescriptionText;
+		}else if (desc.type == 12) {
+			data.culturalHistoryEn = desc.descriptionText;
+			data.culturalHistoryFr = desc.fR_DescriptionText;
 		}
 	}
 

--- a/api/routes/register-router.ts
+++ b/api/routes/register-router.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from 'express';
-import { query } from 'express-validator';
+import { body, query, validationResult } from 'express-validator';
 import { DescriptionService, PhotoService, PlaceService } from '../services';
 import { format, addHours } from 'date-fns';
 import { createThumbnail } from '../utils/image';
@@ -44,6 +44,53 @@ registerRouter.get(
 		res.json({ data });
 	}
 );
+
+
+registerRouter.post(
+	'/search',
+	[query('page').default(1).isInt({ gt: 0 }), body('query').default('').isString().trim()],
+	async (req: Request, res: Response) => {
+		const errors = validationResult(req);
+
+		if (!errors.isEmpty()) {
+			return res.status(422).json({ errors: errors.array() });
+		}
+
+		const page = parseInt(req.query.page as string);
+		const skip = (page - 1) * PAGE_SIZE;
+		const take = PAGE_SIZE;
+		const searchTerm = (req.body.query as string) ?? '';
+
+		const data = searchTerm
+			? await placeService.searchRegister(searchTerm, skip, take)
+			: await placeService.getRegisterAll(skip, take);
+		data.map(
+			(d) => (d.recognitionDate = d.recognitionDate ? format(addHours(new Date(d.recognitionDate), 7), 'yyyy-MM-dd') : null)
+		);
+
+		const item_count = await (searchTerm
+			? placeService.getRegisterSearchCount(searchTerm)
+			: placeService.getPlaceInRegisterCount()
+		)
+			.then((data) => data)
+			.catch((err) => {
+				console.error('Database Error', err);
+				return 0;
+			});
+
+		const page_count = Math.ceil(item_count / PAGE_SIZE);
+
+		if (data) {
+			return res.json({
+				data,
+				meta: { page, page_size: PAGE_SIZE, item_count, page_count },
+			});
+		}
+
+		res.json({ data });
+	}
+);
+
 
 registerRouter.get('/:id', async (req: Request, res: Response) => {
 	const { id } = req.params;

--- a/api/services/place-service.ts
+++ b/api/services/place-service.ts
@@ -127,6 +127,75 @@ export class PlaceService {
 			.limit(take);
 	}
 
+	// Matches the register search term against the place's primary names,
+	// its secondary names, and its place description (both languages).
+	private scopeRegisterToSearchTerm(queryBuilder: Knex.QueryBuilder, searchTerm: string) {
+		const term = `%${searchTerm.trim().replace(/[[\]%_]/g, '\\$&')}%`;
+
+		queryBuilder.where((builder) => {
+			builder
+				.whereRaw("place.primaryName like ? escape '\\'", [term])
+				.orWhereRaw("place.fr_primaryName like ? escape '\\'", [term])
+				.orWhereExists((sub) =>
+					sub
+						.select(db.raw('1'))
+						.from('name')
+						.whereRaw('name.placeId = place.id')
+						.whereRaw("name.description like ? escape '\\'", [term])
+				)
+				.orWhereExists((sub) =>
+					sub
+						.select(db.raw('1'))
+						.from('description')
+						.whereRaw('description.placeId = place.id')
+						.where('description.type', DescriptionTypeEnums.PlaceDescription)
+						.where((descBuilder) =>
+							descBuilder
+								.whereRaw("description.descriptionText like ? escape '\\'", [term])
+								.orWhereRaw("description.fR_DescriptionText like ? escape '\\'", [term])
+						)
+				);
+		});
+	}
+
+	async searchRegister(searchTerm: string, skip: number, take: number): Promise<Array<any>> {
+		const query = db('place')
+			.select([...REGISTER_FIELDS, 'PH.ThumbFile', 'PH.caption'])
+			.join('community', 'community.id', 'place.communityid')
+			.joinRaw(
+				`outer apply (
+					select top 1 photo.ThumbFile, photo.caption
+					from dbo.photo as photo
+					where photo.PlaceId = place.Id
+					AND photo.showInRegister = 1
+					AND photo.IsYRHPCoverImage = 1
+					ORDER by photo.YRHPOrder asc, photo.DateCreated asc, photo.Id asc
+				) as PH`
+			)
+			.where({ 'place.showInRegister': true })
+			.whereNull('place.deleted_at')
+			.orderBy('place.Id')
+			.offset(skip)
+			.limit(take);
+
+		this.scopeRegisterToSearchTerm(query, searchTerm);
+
+		return query;
+	}
+
+	async getRegisterSearchCount(searchTerm: string): Promise<number> {
+		const query = db('place')
+			.count('*', { as: 'count' })
+			.where({ 'place.showInRegister': true })
+			.whereNull('place.deleted_at');
+
+		this.scopeRegisterToSearchTerm(query, searchTerm);
+
+		const results = await query;
+
+		return results && results.length ? (results[0].count as number) : 0;
+	}
+
 	async getPlaceInRegisterCount(): Promise<number> {
 		return new Promise(async (resolve, reject) => {
 			const results = await db('place')


### PR DESCRIPTION
This pull request adds a search endpoint to the register API, enabling advanced search functionality for registered places, and enhances the place details response with additional cultural history fields. The main changes include the new `/search` POST endpoint, robust search logic in `PlaceService`, and support for new fields in place details.

### Search functionality enhancements

* Added a new `POST /register/search` endpoint in `register-router.ts` that allows searching registered places by a query string, with pagination and input validation. The endpoint returns search results and metadata including page count and item count.
* Implemented `searchRegister` and `getRegisterSearchCount` methods in `PlaceService` to perform search queries against primary/secondary names and place descriptions, supporting both English and French fields.
* Added `scopeRegisterToSearchTerm` helper method in `PlaceService` to build robust, SQL-injection-safe search queries that match the search term across multiple fields and tables.

### Place details API enhancements

* Extended the place details response to include new fields: `culturalHistoryEn` and `culturalHistoryFr`, which are populated from description records of type 12. [[1]](diffhunk://#diff-5feaaf0349c65c534af9f1a041cc2051275fb435594aa03ef6963a90089de400R113-R114) [[2]](diffhunk://#diff-5feaaf0349c65c534af9f1a041cc2051275fb435594aa03ef6963a90089de400R134-R136)

### Validation improvements

* Updated route imports to include `body` and `validationResult` from `express-validator` to support request validation for the new endpoint.